### PR TITLE
feat: add auto-merging approved PRs for GitHub Actions

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,22 @@
+name: Automerge
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  automerge:
+    name: Automerge
+    runs-on: ubuntu-latest
+    steps:
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.16.2"
+        env:
+          # This needs to be a PAT to trigger the on-commit pipeline
+          GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}"
+          MERGE_DELETE_BRANCH: "true"
+          MERGE_FILTER_AUTHOR: "github-actions[bot]"
+          MERGE_LABELS: "!wip"
+          MERGE_METHOD: "squash"


### PR DESCRIPTION
This is a pre-requisite to make reviewing PRs and auto-deploying PRs by non-chaotic-aur members feasible. I'm picturing a separate org group with no write access, who could still review the stuff without causing additional actions needed by the actual staff.

A PAT is *required* to trigger the on-commit event. Using GITHUB_TOKEN, this does not get triggered and fails any scheduled pipeline after the merge event.