### PR TITLE
feat: allow manually scheduling packages on GitLab CI

### DIFF
--- a/.ci/manual-schedule.sh
+++ b/.ci/manual-schedule.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+source .ci/util.shlib
+
+# This script is used to manually trigger a build via pipeline UI
+# CI_MANUAL_BUILD is a ":" separated list of package names and needs
+# to be supplied via pipeline variables
+
+# Read config file into global variables
+UTIL_READ_CONFIG_FILE
+
+if [ "$CI_MANUAL_BUILD" == "all" ]; then
+    .ci/schedule-packages.sh schedule all
+    exit 0
+fi
+
+IFS=':' read -r -a PACKAGES <<<"$CI_MANUAL_BUILD"
+.ci/schedule-packages.sh schedule "${PACKAGES[@]}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ on-commit:
     expire_in: 1 hour
   resource_group: chaotic
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $SCHEDULED != "1"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $SCHEDULED != "1" && $CI_MANUAL_BUILD == null
 
 on-schedule:
   stage: process
@@ -37,6 +37,19 @@ on-schedule:
   resource_group: chaotic
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $SCHEDULED == "1"
+
+manual-schedule:
+  stage: process
+  image: alpine:latest
+  script:
+    - .ci/manual-schedule.sh
+  artifacts:
+    paths:
+      - .ci/schedule-params.txt
+    expire_in: 1 hour
+  resource_group: chaotic
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_MANUAL_BUILD != null
 
 do-schedule:
   stage: schedule


### PR DESCRIPTION
This works by using the run pipeline button in combination with supplying CI_MANUAL_BUILD as additional environment variable. The variable needs to be filled as follows: `pkgname1:pkgname2:pkgname3`.