### PR TITLE
feat(on-schedule): implement automated lib rebuilds

### DIFF
--- a/.ci/create-pr.sh
+++ b/.ci/create-pr.sh
@@ -4,38 +4,38 @@ set -euo pipefail
 # $1: pkgbase
 
 if [ -z "${ACCESS_TOKEN:-}" ]; then
-    echo "ERROR: ACCESS_TOKEN is not set. Please set it to a valid access token to use human review or disable CI_HUMAN_REVIEW."
-    exit 0
+	echo "ERROR: ACCESS_TOKEN is not set. Please set it to a valid access token to use human review or disable CI_HUMAN_REVIEW."
+	exit 0
 fi
 
 # $1: pkgbase
 # $2: branch
 # $3: target branch
 function create_gitlab_pr() {
-    local pkgbase="$1"
-    local branch="$2"
-    local target_branch="$3"
+	local pkgbase="$1"
+	local branch="$2"
+	local target_branch="$3"
 
-    # Taken from https://about.gitlab.com/2017/09/05/how-to-automatically-create-a-new-mr-on-gitlab-with-gitlab-ci/
-    # Require a list of all the merge request and take a look if there is already
-    # one with the same source branch
-    local _COUNTBRANCHES _LISTMR _MR_EXISTS BODY
-    if ! _LISTMR=$(curl --fail-with-body --silent "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/merge_requests?state=opened" --header "PRIVATE-TOKEN:${ACCESS_TOKEN}"); then
-        echo "ERROR: $pkgbase: Failed to get list of merge requests." >&2
-        return
-    fi
+	# Taken from https://about.gitlab.com/2017/09/05/how-to-automatically-create-a-new-mr-on-gitlab-with-gitlab-ci/
+	# Require a list of all the merge request and take a look if there is already
+	# one with the same source branch
+	local _COUNTBRANCHES _LISTMR _MR_EXISTS BODY
+	if ! _LISTMR=$(curl --fail-with-body --silent "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/merge_requests?state=opened" --header "PRIVATE-TOKEN:${ACCESS_TOKEN}"); then
+		echo "ERROR: $pkgbase: Failed to get list of merge requests." >&2
+		return
+	fi
 
-    _COUNTBRANCHES=$(grep -o "\"source_branch\":\"${branch}\"" <<<"${_LISTMR}" | wc -l || true)
+	_COUNTBRANCHES=$(grep -o "\"source_branch\":\"${branch}\"" <<<"${_LISTMR}" | wc -l || true)
 
-    if [ "${_COUNTBRANCHES}" == "0" ]; then
-        _MR_EXISTS=0
-    else
-        _MR_EXISTS=1
-    fi
+	if [ "${_COUNTBRANCHES}" == "0" ]; then
+		_MR_EXISTS=0
+	else
+		_MR_EXISTS=1
+	fi
 
-    # The description of our new MR, we want to remove the branch after the MR has
-    # been closed
-    BODY="{
+	# The description of our new MR, we want to remove the branch after the MR has
+	# been closed
+	BODY="{
 	\"project_id\": ${CI_PROJECT_ID},
 	\"source_branch\": \"${branch}\",
 	\"target_branch\": \"${target_branch}\",
@@ -49,48 +49,48 @@ function create_gitlab_pr() {
 	\"labels\": \"ci,human-review,update\"
 	}"
 
-    # No MR found, let's create a new one
-    if [ "$_MR_EXISTS" == 0 ]; then
-        curl --fail-with-body -s -X POST "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/merge_requests" \
-            --header "PRIVATE-TOKEN:${ACCESS_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "${BODY}" && echo "$pkgbase: Created merge request." || echo "ERROR: $pkgbase: Failed to create merge request." >&2
-    else
-        echo "$pkgbase: No new merge request opened due to an already existing MR."
-    fi
+	# No MR found, let's create a new one
+	if [ "$_MR_EXISTS" == 0 ]; then
+		curl --fail-with-body -s -X POST "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/merge_requests" \
+			--header "PRIVATE-TOKEN:${ACCESS_TOKEN}" \
+			--header "Content-Type: application/json" \
+			--data "${BODY}" && echo "$pkgbase: Created merge request." || echo "ERROR: $pkgbase: Failed to create merge request." >&2
+	else
+		echo "$pkgbase: No new merge request opened due to an already existing MR."
+	fi
 }
 
 # $1: pkgbase
 # $2: branch
 # $3: target branch
 function create_github_pr() {
-    local pkgbase="$1"
-    local branch="$2"
-    local target_branch="$3"
+	local pkgbase="$1"
+	local branch="$2"
+	local target_branch="$3"
 
-    # Taken from https://about.gitlab.com/2017/09/05/how-to-automatically-create-a-new-mr-on-gitlab-with-gitlab-ci/
-    # Require a list of all the merge request and take a look if there is already
-    # one with the same source branch
-    local _COUNTBRANCHES _LISTMR _MR_EXISTS BODY
-    if ! _LISTMR=$(curl --fail-with-body --silent "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls?state=open&head=$GITHUB_REPOSITORY_OWNER:$branch" \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        -H "Authorization: token ${ACCESS_TOKEN}"); then
-        echo "ERROR: $pkgbase: Failed to get list of pull requests." >&2
-        return
-    fi
+	# Taken from https://about.gitlab.com/2017/09/05/how-to-automatically-create-a-new-mr-on-gitlab-with-gitlab-ci/
+	# Require a list of all the merge request and take a look if there is already
+	# one with the same source branch
+	local _COUNTBRANCHES _LISTMR _MR_EXISTS BODY
+	if ! _LISTMR=$(curl --fail-with-body --silent "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls?state=open&head=$GITHUB_REPOSITORY_OWNER:$branch" \
+		-H "Accept: application/vnd.github+json" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
+		-H "Authorization: token ${ACCESS_TOKEN}"); then
+		echo "ERROR: $pkgbase: Failed to get list of pull requests." >&2
+		return
+	fi
 
-    _COUNTBRANCHES=$(jq length <<<"${_LISTMR}" || true)
+	_COUNTBRANCHES=$(jq length <<<"${_LISTMR}" || true)
 
-    if [ "${_COUNTBRANCHES}" == "0" ]; then
-        _MR_EXISTS=0
-    else
-        _MR_EXISTS=1
-    fi
+	if [ "${_COUNTBRANCHES}" == "0" ]; then
+		_MR_EXISTS=0
+	else
+		_MR_EXISTS=1
+	fi
 
-    # The description of our new MR, we want to remove the branch after the MR has
-    # been closed
-    BODY="{
+	# The description of our new MR, we want to remove the branch after the MR has
+	# been closed
+	BODY="{
 	\"head\": \"${branch}\",
 	\"base\": \"${target_branch}\",
 	\"maintainer_can_modify\": true,
@@ -98,59 +98,59 @@ function create_github_pr() {
 	\"body\": \"A recent update of this package requires human review! Please check whether any potentially dangerous changes were made.\"
 	}"
 
-    # No MR found, let's create a new one
-    if [ "$_MR_EXISTS" == 0 ]; then
-        # PR doesn't exist, create a new one
-        curl --fail-with-body -s -X POST "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: token ${ACCESS_TOKEN}" \
-            --data "${BODY}" && echo "$pkgbase: Created pull request." || echo "ERROR: $pkgbase Failed to create pull request." >&2
-    else
-        echo "$pkgbase: No new pull request opened due to an already existing MR."
-    fi
+	# No MR found, let's create a new one
+	if [ "$_MR_EXISTS" == 0 ]; then
+		# PR doesn't exist, create a new one
+		curl --fail-with-body -s -X POST "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls" \
+			-H "Accept: application/vnd.github+json" \
+			-H "X-GitHub-Api-Version: 2022-11-28" \
+			-H "Authorization: token ${ACCESS_TOKEN}" \
+			--data "${BODY}" && echo "$pkgbase: Created pull request." || echo "ERROR: $pkgbase Failed to create pull request." >&2
+	else
+		echo "$pkgbase: No new pull request opened due to an already existing MR."
+	fi
 }
 
 # $1: branch
 # $2: target branch
 # $3: pkgbase
 function manage_branch() {
-    local branch="$1"
-    local target_branch="$2"
-    local pkgbase="$3"
+	local branch="$1"
+	local target_branch="$2"
+	local pkgbase="$3"
 
-    git stash
-    if git show-ref --quiet "origin/$branch"; then
-        git switch "$branch"
-        git checkout stash -- "$pkgbase"
-        # Branch already exists, let's see if it's up to date
-        # Also check if previous parent commit is no longer ancestor of target_branch
-        if ! git diff --staged --exit-code --quiet || ! git merge-base --is-ancestor HEAD^ "origin/$target_branch"; then
-            # Not up to date
-            git reset --hard "origin/$target_branch"
-            git checkout stash -- "$pkgbase"
-            git commit -m "chore($1): PKGBUILD modified"
-            git push --force-with-lease origin "$CHANGE_BRANCH"
-        fi
-    else
-        # Branch does not exist, let's create it
-        git switch -C "$branch" "origin/$target_branch"
-        git checkout stash -- "$pkgbase"
-        git commit -m "chore($1): PKGBUILD modified"
-        git push --force-with-lease origin "$CHANGE_BRANCH"
-    fi
-    git stash drop
+	git stash
+	if git show-ref --quiet "origin/$branch"; then
+		git switch "$branch"
+		git checkout stash -- "$pkgbase"
+		# Branch already exists, let's see if it's up to date
+		# Also check if previous parent commit is no longer ancestor of target_branch
+		if ! git diff --staged --exit-code --quiet || ! git merge-base --is-ancestor HEAD^ "origin/$target_branch"; then
+			# Not up to date
+			git reset --hard "origin/$target_branch"
+			git checkout stash -- "$pkgbase"
+			git commit -m "chore($1): PKGBUILD modified"
+			git push --force-with-lease origin "$CHANGE_BRANCH"
+		fi
+	else
+		# Branch does not exist, let's create it
+		git switch -C "$branch" "origin/$target_branch"
+		git checkout stash -- "$pkgbase"
+		git commit -m "chore($1): PKGBUILD modified"
+		git push --force-with-lease origin "$CHANGE_BRANCH"
+	fi
+	git stash drop
 }
 
 PKGBASE="$1"
 
 if [ -v CI_COMMIT_REF_NAME ]; then
-    TARGET_BRANCH="$CI_COMMIT_REF_NAME"
+	TARGET_BRANCH="$CI_COMMIT_REF_NAME"
 elif [ -v GITHUB_REF_NAME ]; then
-    TARGET_BRANCH="$GITHUB_REF_NAME"
+	TARGET_BRANCH="$GITHUB_REF_NAME"
 else
-    # Current branch name
-    TARGET_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+	# Current branch name
+	TARGET_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 fi
 
 ORIGINAL_REF="$(git rev-parse HEAD)"
@@ -159,12 +159,12 @@ CHANGE_BRANCH="update-$PKGBASE"
 manage_branch "$CHANGE_BRANCH" "$TARGET_BRANCH" "$PKGBASE"
 
 if [ -v GITLAB_CI ]; then
-    create_gitlab_pr "$PKGBASE" "$CHANGE_BRANCH" "$TARGET_BRANCH"
+	create_gitlab_pr "$PKGBASE" "$CHANGE_BRANCH" "$TARGET_BRANCH"
 elif [ -v GITHUB_ACTIONS ]; then
-    create_github_pr "$PKGBASE" "$CHANGE_BRANCH" "$TARGET_BRANCH"
+	create_github_pr "$PKGBASE" "$CHANGE_BRANCH" "$TARGET_BRANCH"
 else
-    echo "WARNING: Pull request creation is only supported on GitLab CI/GitHub Actions. Please disable CI_HUMAN_REVIEW." >&2
-    exit 0
+	echo "WARNING: Pull request creation is only supported on GitLab CI/GitHub Actions. Please disable CI_HUMAN_REVIEW." >&2
+	exit 0
 fi
 
 # Switch back to the original branch

--- a/.ci/manual-schedule.sh
+++ b/.ci/manual-schedule.sh
@@ -12,8 +12,8 @@ source .ci/util.shlib
 UTIL_READ_CONFIG_FILE
 
 if [ "$PACKAGES" == "all" ]; then
-    .ci/schedule-packages.sh schedule all
-    exit 0
+	.ci/schedule-packages.sh schedule all
+	exit 0
 fi
 
 declare -a FINAL=()

--- a/.ci/on-commit.sh
+++ b/.ci/on-commit.sh
@@ -11,87 +11,87 @@ UTIL_READ_CONFIG_FILE
 declare -A PACKAGES=()
 
 function populate_commit_info() {
-    COMMITS=()
-    COMMIT_MESSAGES=()
+	COMMITS=()
+	COMMIT_MESSAGES=()
 
-    # We rely on the "scheduled" tag to be present in the repo to determine which commits to parse
-    if ! [ "$(git tag -l "scheduled")" ]; then
-        # If not present, we assume only the latest commit to be relevant
-        COMMITS=("$(git rev-parse HEAD)")
-        mapfile -t CHANGED_FILES < <(git diff-tree --no-commit-id --name-only -r HEAD)
-    else
-        # If present, we parse all commits between the "scheduled" tag and HEAD
-        # This is required because CI may sometimes run on multiple commits at once,
-        # resulting in only one pipeline run for multiple commits
-        mapfile -t COMMITS < <(git rev-list scheduled..HEAD)
-        mapfile -t CHANGED_FILES < <(git diff-tree --no-commit-id --name-only -r scheduled..HEAD)
-    fi
+	# We rely on the "scheduled" tag to be present in the repo to determine which commits to parse
+	if ! [ "$(git tag -l "scheduled")" ]; then
+		# If not present, we assume only the latest commit to be relevant
+		COMMITS=("$(git rev-parse HEAD)")
+		mapfile -t CHANGED_FILES < <(git diff-tree --no-commit-id --name-only -r HEAD)
+	else
+		# If present, we parse all commits between the "scheduled" tag and HEAD
+		# This is required because CI may sometimes run on multiple commits at once,
+		# resulting in only one pipeline run for multiple commits
+		mapfile -t COMMITS < <(git rev-list scheduled..HEAD)
+		mapfile -t CHANGED_FILES < <(git diff-tree --no-commit-id --name-only -r scheduled..HEAD)
+	fi
 
-    # Check if the array of commits is empty
-    if [ ${#COMMITS[@]} -eq 0 ]; then
-        echo "No commits detected since last CI run."
-    fi
+	# Check if the array of commits is empty
+	if [ ${#COMMITS[@]} -eq 0 ]; then
+		echo "No commits detected since last CI run."
+	fi
 
-    # Get commit messages for each commit
-    for commit in "${COMMITS[@]}"; do
-        COMMIT_MESSAGES+=("$(git log --format=%B -n 1 "$commit")")
-    done
+	# Get commit messages for each commit
+	for commit in "${COMMITS[@]}"; do
+		COMMIT_MESSAGES+=("$(git log --format=%B -n 1 "$commit")")
+	done
 }
 
 function parse_commit_messages() {
-    for i in "${!COMMIT_MESSAGES[@]}"; do
-        local message="${COMMIT_MESSAGES[$i]}"
-        local commit="${COMMITS[$i]}"
-        local regex="\[deploy ([a-z0-9_ -]+)\]"
-        if [[ "$message" =~ $regex ]]; then
-            local potential_packages
-            mapfile -t potential_packages <<<"${BASH_REMATCH[1]}"
-            for package in "${potential_packages[@]}"; do
-                case "$package" in
-                all)
-                    PACKAGES["all"]=1
-                    echo "Rebuild of all packages requested via commit message (${commit:0:7})."
-                    return
-                    ;;
-                *)
-                    if [ -d "$package" ]; then
-                        PACKAGES["$package"]=1
-                        echo "Rebuild of $package requested via commit message (${commit:0:7})."
-                    else
-                        echo "FATAL: Package $package requested but does not exist! Remove the package from the commit message (${commit:0:7}) and force push." >&2
-                        exit 1
-                    fi
-                    ;;
-                esac
-            done
-        fi
-    done
+	for i in "${!COMMIT_MESSAGES[@]}"; do
+		local message="${COMMIT_MESSAGES[$i]}"
+		local commit="${COMMITS[$i]}"
+		local regex="\[deploy ([a-z0-9_ -]+)\]"
+		if [[ "$message" =~ $regex ]]; then
+			local potential_packages
+			mapfile -t potential_packages <<<"${BASH_REMATCH[1]}"
+			for package in "${potential_packages[@]}"; do
+				case "$package" in
+				all)
+					PACKAGES["all"]=1
+					echo "Rebuild of all packages requested via commit message (${commit:0:7})."
+					return
+					;;
+				*)
+					if [ -d "$package" ]; then
+						PACKAGES["$package"]=1
+						echo "Rebuild of $package requested via commit message (${commit:0:7})."
+					else
+						echo "FATAL: Package $package requested but does not exist! Remove the package from the commit message (${commit:0:7}) and force push." >&2
+						exit 1
+					fi
+					;;
+				esac
+			done
+		fi
+	done
 }
 
 function parse_changed_files() {
-    declare -A CHANGED_ROOT_FOLDERS
+	declare -A CHANGED_ROOT_FOLDERS
 
-    for file in "${CHANGED_FILES[@]}"; do
-        # Exclude folders starting with a dot
-        if [[ "${file:0:1}" == "." ]]; then
-            continue
-        fi
+	for file in "${CHANGED_FILES[@]}"; do
+		# Exclude folders starting with a dot
+		if [[ "${file:0:1}" == "." ]]; then
+			continue
+		fi
 
-        # Extract the root folder of the changed file
-        if [[ "$file" =~ ^([a-z0-9_-]+)/ ]]; then
-            local folder="${BASH_REMATCH[1]}"
-            if [ -d "$folder" ]; then
-                CHANGED_ROOT_FOLDERS["$folder"]=1
-            else
-                PACKAGE_REMOVED=true
-            fi
-        fi
-    done
+		# Extract the root folder of the changed file
+		if [[ "$file" =~ ^([a-z0-9_-]+)/ ]]; then
+			local folder="${BASH_REMATCH[1]}"
+			if [ -d "$folder" ]; then
+				CHANGED_ROOT_FOLDERS["$folder"]=1
+			else
+				PACKAGE_REMOVED=true
+			fi
+		fi
+	done
 
-    for folder in "${!CHANGED_ROOT_FOLDERS[@]}"; do
-        PACKAGES["$folder"]=1
-        echo "Executing rebuild of $folder due to changes in the folder."
-    done
+	for folder in "${!CHANGED_ROOT_FOLDERS[@]}"; do
+		PACKAGES["$folder"]=1
+		echo "Executing rebuild of $folder due to changes in the folder."
+	done
 }
 
 PACKAGE_REMOVED=false
@@ -107,19 +107,19 @@ parse_changed_files
 
 # Check if we have any packages to build
 if [ ${#PACKAGES[@]} -eq 0 ] && [ "$PACKAGE_REMOVED" = false ]; then
-    echo "No packages to build, exiting gracefully."
+	echo "No packages to build, exiting gracefully."
 else
-    if [ ${#PACKAGES[@]} -ne 0 ]; then
-        # Check if we have to build all packages
-        if [[ -v "PACKAGES[all]" ]]; then
-            .ci/schedule-packages.sh schedule all
-        else
-            .ci/schedule-packages.sh schedule "${!PACKAGES[@]}"
-        fi
-    fi
-    if [ "$PACKAGE_REMOVED" = true ]; then
-        .ci/schedule-packages.sh auto-repo-remove
-    fi
+	if [ ${#PACKAGES[@]} -ne 0 ]; then
+		# Check if we have to build all packages
+		if [[ -v "PACKAGES[all]" ]]; then
+			.ci/schedule-packages.sh schedule all
+		else
+			.ci/schedule-packages.sh schedule "${!PACKAGES[@]}"
+		fi
+	fi
+	if [ "$PACKAGE_REMOVED" = true ]; then
+		.ci/schedule-packages.sh auto-repo-remove
+	fi
 fi
 
 git tag -f scheduled

--- a/.ci/on-schedule.sh
+++ b/.ci/on-schedule.sh
@@ -13,41 +13,43 @@ export TMPDIR="${TMPDIR:-/tmp}"
 
 # Special case: We are told to trigger a specific trigger
 if [ -v TRIGGER ]; then
-    PACKAGES=()
-    TO_BUILD=()
-    UTIL_GET_PACKAGES PACKAGES
-    for package in "${PACKAGES[@]}"; do
-        unset VARIABLES
-        declare -A VARIABLES
-        if UTIL_READ_MANAGED_PACAKGE "$package" VARIABLES; then
-            if [ -v "VARIABLES[CI_ON_TRIGGER]" ]; then
-                if [ "${VARIABLES[CI_ON_TRIGGER]}" == "$TRIGGER" ]; then
-                    TO_BUILD+=("$package")
-                fi
-            fi
-        fi
-    done
-    if [ ${#TO_BUILD[@]} -ne 0 ]; then
-        .ci/schedule-packages.sh schedule "${TO_BUILD[@]}"
-    fi
-    exit 0
+	PACKAGES=()
+	TO_BUILD=()
+	UTIL_GET_PACKAGES PACKAGES
+	for package in "${PACKAGES[@]}"; do
+		unset VARIABLES
+		declare -A VARIABLES
+		if UTIL_READ_MANAGED_PACAKGE "$package" VARIABLES; then
+			if [ -v "VARIABLES[CI_ON_TRIGGER]" ]; then
+				if [ "${VARIABLES[CI_ON_TRIGGER]}" == "$TRIGGER" ]; then
+					TO_BUILD+=("$package")
+				fi
+			fi
+		fi
+	done
+	if [ ${#TO_BUILD[@]} -ne 0 ]; then
+		.ci/schedule-packages.sh schedule "${TO_BUILD[@]}"
+	fi
+	exit 0
 fi
 
 git config --global user.name "$GIT_AUTHOR_NAME"
 git config --global user.email "$GIT_AUTHOR_EMAIL"
 
 if [ -v TEMPLATE_ENABLE_UPDATES ] && [ "$TEMPLATE_ENABLE_UPDATES" == "true" ]; then
-    .ci/update-template.sh && echo "Info: Updated CI template." && exit 0 || true
+	.ci/update-template.sh && echo "Info: Updated CI template." && exit 0 || true
 fi
 
 # Check if the scheduled tag does not exist or scheduled does not point to HEAD
 if ! [ "$(git tag -l "scheduled")" ] || [ "$(git rev-parse HEAD)" != "$(git rev-parse scheduled)" ]; then
-    echo "Previous on-commit pipeline did not seem to run successfully. Aborting." >&2
-    exit 1
+	echo "Previous on-commit pipeline did not seem to run successfully. Aborting." >&2
+	exit 1
 fi
 
 PACKAGES=()
 declare -A AUR_TIMESTAMPS
+declare -A LIB_VERSIONS_NEW
+NEEDS_BUMP=()
 MODIFIED_PACKAGES=()
 DELETE_BRANCHES=()
 UTIL_GET_PACKAGES PACKAGES
@@ -56,43 +58,79 @@ COMMIT="${COMMIT:-false}"
 # Loop through all packages to do optimized aur RPC calls
 # $1 = Output associative array
 function collect_aur_timestamps() {
-    # shellcheck disable=SC2034
-    local -n collect_aur_timestamps_output=$1
-    local AUR_PACKAGES=()
+	# shellcheck disable=SC2034
+	local -n collect_aur_timestamps_output=$1
+	local AUR_PACKAGES=()
 
-    for package in "${PACKAGES[@]}"; do
-        unset VARIABLES
-        declare -gA VARIABLES
-        if UTIL_READ_MANAGED_PACAKGE "$package" VARIABLES; then
-            if [ -v "VARIABLES[CI_PKGBUILD_SOURCE]" ]; then
-                local PKGBUILD_SOURCE="${VARIABLES[CI_PKGBUILD_SOURCE]}"
-                if [[ "$PKGBUILD_SOURCE" == aur ]]; then
-                    AUR_PACKAGES+=("$package")
-                fi
-            fi
-        fi
-    done
+	for package in "${PACKAGES[@]}"; do
+		unset VARIABLES
+		declare -gA VARIABLES
+		if UTIL_READ_MANAGED_PACAKGE "$package" VARIABLES; then
+			if [ -v "VARIABLES[CI_PKGBUILD_SOURCE]" ]; then
+				local PKGBUILD_SOURCE="${VARIABLES[CI_PKGBUILD_SOURCE]}"
+				if [[ "$PKGBUILD_SOURCE" == aur ]]; then
+					AUR_PACKAGES+=("$package")
+				fi
+			fi
+		fi
+	done
 
-    # Get all timestamps from AUR
-    UTIL_FETCH_AUR_TIMESTAMPS collect_aur_timestamps_output "${AUR_PACKAGES[*]}"
+	# Get all timestamps from AUR
+	UTIL_FETCH_AUR_TIMESTAMPS collect_aur_timestamps_output "${AUR_PACKAGES[*]}"
+}
+
+function fetch_arch_versions() {
+	local -n collect_arch_version_output=$1
+	UTIL_FETCH_ARCH_REPO_VERSIONS collect_arch_version_output "${KNOWN_REBUILD_DEPS[*]}"
+}
+
+function check_library_bumps() {
+	local file=.ci/lib-versions
+	UTIL_READ_VARIABLES_FROM_FILE $file VARIABLE_VERSIONS
+	fetch_arch_versions LIB_VERSIONS_NEW
+
+	for i in "${!LIB_VERSIONS_NEW[@]}"; do
+		if [[ ${LIB_VERSIONS_NEW[$i]} != "${VARIABLE_VERSIONS[$i]}" ]]; then
+			NEEDS_BUMP+=("$i")
+		fi
+	done
+
+	if [[ ${#NEEDS_BUMP[@]} != 0 ]]; then
+		true >"$file"
+		for i in "${!LIB_VERSIONS_NEW[@]}"; do
+			echo "${i/_new/}=${LIB_VERSIONS_NEW[$i]}" >>"$file"
+		done
+	fi
+}
+
+function do_lib_bump() {
+	local -n VARIABLES_LIB_BUMP=${1:-VARIABLES}
+	local pkgrel="${VARIABLES_LIB_BUMP[CI_PKGREL]}"
+	local known_deps=("${VARIABLES_LIB_BUMP[CI_DEP_REBUILD]}")
+
+	# One match is sufficient, even if multiple libs were updated
+	if [[ ${known_deps[*]} == *"${TO_BUMP[*]}"* ]]; then
+		pkgrel=$((pkgrel++))
+		UTIL_UPDATE_PKGREL VARIABLES_LIB_BUMP "$pkgrel"
+	fi
 }
 
 # $1: dir1
 # $2: dir2
 function package_changed() {
-    # Check if the package has changed
-    # NOTE: We don't care if anything but the PKGBUILD or .SRCINFO has changed.
-    # Any properly built PKGBUILD will use hashes, which will change
-    if diff -q "$1/PKGBUILD" "$2/PKGBUILD" >/dev/null; then
-        if [ ! -f "$1/.SRCINFO" ] && [ ! -f "$2/.SRCINFO" ]; then
-            return 1
-        elif [ -f "$1/.SRCINFO" ] && [ -f "$2/.SRCINFO" ]; then
-            if diff -q "$1/.SRCINFO" "$2/.SRCINFO" >/dev/null; then
-                return 1
-            fi
-        fi
-    fi
-    return 0
+	# Check if the package has changed
+	# NOTE: We don't care if anything but the PKGBUILD or .SRCINFO has changed.
+	# Any properly built PKGBUILD will use hashes, which will change
+	if diff -q "$1/PKGBUILD" "$2/PKGBUILD" >/dev/null; then
+		if [ ! -f "$1/.SRCINFO" ] && [ ! -f "$2/.SRCINFO" ]; then
+			return 1
+		elif [ -f "$1/.SRCINFO" ] && [ -f "$2/.SRCINFO" ]; then
+			if diff -q "$1/.SRCINFO" "$2/.SRCINFO" >/dev/null; then
+				return 1
+			fi
+		fi
+	fi
+	return 0
 }
 
 # Check if the package has gotten major changes
@@ -100,220 +138,233 @@ function package_changed() {
 # $1: dir1
 # $2: dir2
 function package_major_change() {
-    local sdiff_output
-    if sdiff_output="$(sdiff -ds <(gawk -f .ci/awk/remove-checksum.awk "$1/PKGBUILD") <(gawk -f .ci/awk/remove-checksum.awk "$2/PKGBUILD"))"; then
-        return 1
-    fi
+	local sdiff_output
+	if sdiff_output="$(sdiff -ds <(gawk -f .ci/awk/remove-checksum.awk "$1/PKGBUILD") <(gawk -f .ci/awk/remove-checksum.awk "$2/PKGBUILD"))"; then
+		return 1
+	fi
 
-    if [ $? -eq 2 ]; then
-        echo "Warning: sdiff failed" >&2
-        return 2
-    fi
+	if [ $? -eq 2 ]; then
+		echo "Warning: sdiff failed" >&2
+		return 2
+	fi
 
-    if gawk -f .ci/awk/check-diff.awk <<<"$sdiff_output"; then
-        # Check the rest of the files in the folder for changes
-        # Excluding PKGBUILD .SRCINFO, .gitignore, .git .CI
-        # shellcheck disable=SC2046
-        if diff -q $(UTIL_GET_EXCLUDE_LIST "-x" "PKGBUILD .SRCINFO") -r "$1" "$2" >/dev/null; then
-            return 1
-        fi
-    fi
-    return 0
+	if gawk -f .ci/awk/check-diff.awk <<<"$sdiff_output"; then
+		# Check the rest of the files in the folder for changes
+		# Excluding PKGBUILD .SRCINFO, .gitignore, .git .CI
+		# shellcheck disable=SC2046
+		if diff -q $(UTIL_GET_EXCLUDE_LIST "-x" "PKGBUILD .SRCINFO") -r "$1" "$2" >/dev/null; then
+			return 1
+		fi
+	fi
+	return 0
 }
 
 # $1: VARIABLES
 # $2: git URL
 function update_via_git() {
-    local -n VARIABLES_VIA_GIT=${1:-VARIABLES}
-    local pkgbase="${VARIABLES_VIA_GIT[PKGBASE]}"
+	local -n VARIABLES_VIA_GIT=${1:-VARIABLES}
+	local pkgbase="${VARIABLES_VIA_GIT[PKGBASE]}"
 
-    git clone --depth=1 "$2" "$TMPDIR/aur-pulls/$pkgbase"
+	git clone --depth=1 "$2" "$TMPDIR/aur-pulls/$pkgbase"
 
-    # We always run shfmt on the PKGBUILD. Two runs of shfmt on the same file should not change anything
-    shfmt -w "$TMPDIR/aur-pulls/$pkgbase/PKGBUILD"
+	# We always run shfmt on the PKGBUILD. Two runs of shfmt on the same file should not change anything
+	shfmt -w "$TMPDIR/aur-pulls/$pkgbase/PKGBUILD"
 
-    if package_changed "$TMPDIR/aur-pulls/$pkgbase" "$pkgbase"; then
-        if [ -v CI_HUMAN_REVIEW ] && [ "$CI_HUMAN_REVIEW" == "true" ] && package_major_change "$TMPDIR/aur-pulls/$pkgbase" "$pkgbase"; then
-            echo "Warning: Major change detected in $pkgbase."
-            VARIABLES_VIA_GIT[CI_REQUIRES_REVIEW]=true
-        fi
-        # Rsync: delete files in the destination that are not in the source. Exclude deleting .CI, exclude copying .git
-        # shellcheck disable=SC2046
-        rsync -a --delete $(UTIL_GET_EXCLUDE_LIST "--exclude") "$TMPDIR/aur-pulls/$pkgbase/" "$pkgbase/"
-    fi
+	if package_changed "$TMPDIR/aur-pulls/$pkgbase" "$pkgbase"; then
+		if [ -v CI_HUMAN_REVIEW ] && [ "$CI_HUMAN_REVIEW" == "true" ] && package_major_change "$TMPDIR/aur-pulls/$pkgbase" "$pkgbase"; then
+			echo "Warning: Major change detected in $pkgbase."
+			VARIABLES_VIA_GIT[CI_REQUIRES_REVIEW]=true
+		fi
+		# Rsync: delete files in the destination that are not in the source. Exclude deleting .CI, exclude copying .git
+		# shellcheck disable=SC2046
+		rsync -a --delete $(UTIL_GET_EXCLUDE_LIST "--exclude") "$TMPDIR/aur-pulls/$pkgbase/" "$pkgbase/"
+	fi
 }
 
 # $1: VARIABLES
 # $2: source
 function update_from_gitlab_tag() {
-    local -n VARIABLES_UPDATE_FROM_GITLAB_TAG=${1:-VARIABLES}
-    local pkgbase="${VARIABLES_UPDATE_FROM_GITLAB_TAG[PKGBASE]}"
-    local project_id="${2:-}"
+	local -n VARIABLES_UPDATE_FROM_GITLAB_TAG=${1:-VARIABLES}
+	local pkgbase="${VARIABLES_UPDATE_FROM_GITLAB_TAG[PKGBASE]}"
+	local project_id="${2:-}"
 
-    if [ ! -f "$pkgbase/.SRCINFO" ]; then
-        echo "ERROR: $pkgbase: .SRCINFO does not exist." >&2
-        return
-    fi
+	if [ ! -f "$pkgbase/.SRCINFO" ]; then
+		echo "ERROR: $pkgbase: .SRCINFO does not exist." >&2
+		return
+	fi
 
-    local TAG_OUTPUT
-    if ! TAG_OUTPUT="$(curl --fail-with-body --silent "https://gitlab.com/api/v4/projects/${project_id}/repository/tags?order_by=version&per_page=1")" || [ -z "$TAG_OUTPUT" ]; then
-        echo "ERROR: $pkgbase: Failed to get list of tags." >&2
-        return
-    fi
+	local TAG_OUTPUT
+	if ! TAG_OUTPUT="$(curl --fail-with-body --silent "https://gitlab.com/api/v4/projects/${project_id}/repository/tags?order_by=version&per_page=1")" || [ -z "$TAG_OUTPUT" ]; then
+		echo "ERROR: $pkgbase: Failed to get list of tags." >&2
+		return
+	fi
 
-    local COMMIT_URL VERSION
-    COMMIT_URL="$(jq -r '.[0].commit.web_url' <<<"$TAG_OUTPUT")"
-    VERSION="$(jq -r '.[0].name' <<<"$TAG_OUTPUT")"
+	local COMMIT_URL VERSION
+	COMMIT_URL="$(jq -r '.[0].commit.web_url' <<<"$TAG_OUTPUT")"
+	VERSION="$(jq -r '.[0].name' <<<"$TAG_OUTPUT")"
 
-    if [ -z "$COMMIT_URL" ] || [ -z "$VERSION" ]; then
-        echo "ERROR: $pkgbase: Failed to get latest tag." >&2
-        return
-    fi
+	if [ -z "$COMMIT_URL" ] || [ -z "$VERSION" ]; then
+		echo "ERROR: $pkgbase: Failed to get latest tag." >&2
+		return
+	fi
 
-    # Parse .SRCINFO file for PKGVER
-    local SRCINFO_PKGVER
-    if ! SRCINFO_PKGVER="$(grep -m 1 -oP '\tpkgver\s=\s\K.*$' "$pkgbase/.SRCINFO")"; then
-        echo "ERROR: $pkgbase: Failed to parse PKGVER from .SRCINFO." >&2
-        return
-    fi
+	# Parse .SRCINFO file for PKGVER
+	local SRCINFO_PKGVER
+	if ! SRCINFO_PKGVER="$(grep -m 1 -oP '\tpkgver\s=\s\K.*$' "$pkgbase/.SRCINFO")"; then
+		echo "ERROR: $pkgbase: Failed to parse PKGVER from .SRCINFO." >&2
+		return
+	fi
 
-    # Check if the tag is different from the PKGVER
-    if [ "$VERSION" == "$SRCINFO_PKGVER" ]; then
-        return
-    fi
+	# Check if the tag is different from the PKGVER
+	if [ "$VERSION" == "$SRCINFO_PKGVER" ]; then
+		return
+	fi
 
-    # Extract project URL and commit hash from commit URL
-    local DOWNLOAD_URL BASE_URL COMMIT PROJECT_NAME
-    if [[ "$COMMIT_URL" =~ ^(.*)/([^/]+)/-/commit/([^/]+)$ ]]; then
-        PROJECT_NAME="${BASH_REMATCH[2]}"
-        COMMIT="${BASH_REMATCH[3]}"
-        BASE_URL="${BASH_REMATCH[1]}/${PROJECT_NAME}/-/archive"
-    else
-        echo "ERROR: $pkgbase: Failed to parse commit URL." >&2
-        return
-    fi
+	# Extract project URL and commit hash from commit URL
+	local DOWNLOAD_URL BASE_URL COMMIT PROJECT_NAME
+	if [[ "$COMMIT_URL" =~ ^(.*)/([^/]+)/-/commit/([^/]+)$ ]]; then
+		PROJECT_NAME="${BASH_REMATCH[2]}"
+		COMMIT="${BASH_REMATCH[3]}"
+		BASE_URL="${BASH_REMATCH[1]}/${PROJECT_NAME}/-/archive"
+	else
+		echo "ERROR: $pkgbase: Failed to parse commit URL." >&2
+		return
+	fi
 
-    shfmt -w "$pkgbase/PKGBUILD"
+	shfmt -w "$pkgbase/PKGBUILD"
 
-    gawk -i inplace -f .ci/awk/update-pkgbuild.awk -v TARGET_VERSION="$VERSION" -v BASE_URL="$BASE_URL" -v TARGET_URL="${BASE_URL}/\${_commit}/${PROJECT_NAME}-\${_commit}.tar.gz" -v COMMIT="$COMMIT" "$pkgbase/PKGBUILD"
-    gawk -i inplace -f .ci/awk/update-srcinfo.awk -v TARGET_VERSION="$VERSION" -v BASE_URL="$BASE_URL" -v TARGET_URL="${BASE_URL}/${COMMIT}/${PROJECT_NAME}-${COMMIT}.tar.gz" "$pkgbase/.SRCINFO"
+	gawk -i inplace -f .ci/awk/update-pkgbuild.awk -v TARGET_VERSION="$VERSION" -v BASE_URL="$BASE_URL" -v TARGET_URL="${BASE_URL}/\${_commit}/${PROJECT_NAME}-\${_commit}.tar.gz" -v COMMIT="$COMMIT" "$pkgbase/PKGBUILD"
+	gawk -i inplace -f .ci/awk/update-srcinfo.awk -v TARGET_VERSION="$VERSION" -v BASE_URL="$BASE_URL" -v TARGET_URL="${BASE_URL}/${COMMIT}/${PROJECT_NAME}-${COMMIT}.tar.gz" "$pkgbase/.SRCINFO"
 }
 
 function update_pkgbuild() {
-    local -n VARIABLES_UPDATE_PKGBUILD=${1:-VARIABLES}
-    local pkgbase="${VARIABLES_UPDATE_PKGBUILD[PKGBASE]}"
-    if ! [ -v "VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_SOURCE]" ]; then
-        return 0
-    fi
+	local -n VARIABLES_UPDATE_PKGBUILD=${1:-VARIABLES}
+	local pkgbase="${VARIABLES_UPDATE_PKGBUILD[PKGBASE]}"
+	if ! [ -v "VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_SOURCE]" ]; then
+		return 0
+	fi
 
-    local PKGBUILD_SOURCE="${VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_SOURCE]}"
+	local PKGBUILD_SOURCE="${VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_SOURCE]}"
 
-    # Check if the source starts with gitlab:
-    if [[ "$PKGBUILD_SOURCE" =~ ^gitlab:(.*) ]]; then
-        update_from_gitlab_tag VARIABLES_UPDATE_PKGBUILD "${BASH_REMATCH[1]}"
-    # Check if the package is from the AUR
-    elif [[ "$PKGBUILD_SOURCE" != aur ]]; then
-        update_via_git VARIABLES_UPDATE_PKGBUILD "$PKGBUILD_SOURCE"
-    else
-        local git_url="https://aur.archlinux.org/${pkgbase}.git"
+	# Check if the source starts with gitlab:
+	if [[ "$PKGBUILD_SOURCE" =~ ^gitlab:(.*) ]]; then
+		update_from_gitlab_tag VARIABLES_UPDATE_PKGBUILD "${BASH_REMATCH[1]}"
+	# Check if the package is from the AUR
+	elif [[ "$PKGBUILD_SOURCE" != aur ]]; then
+		update_via_git VARIABLES_UPDATE_PKGBUILD "$PKGBUILD_SOURCE"
+	else
+		local git_url="https://aur.archlinux.org/${pkgbase}.git"
 
-        # Fetch from optimized AUR RPC call
-        if ! [ -v "AUR_TIMESTAMPS[$pkgbase]" ]; then
-            echo "Warning: Could not find $pkgbase in cached AUR timestamps." >&2
-            return 0
-        fi
-        local NEW_TIMESTAMP="${AUR_TIMESTAMPS[$pkgbase]}"
+		# Fetch from optimized AUR RPC call
+		if ! [ -v "AUR_TIMESTAMPS[$pkgbase]" ]; then
+			echo "Warning: Could not find $pkgbase in cached AUR timestamps." >&2
+			return 0
+		fi
+		local NEW_TIMESTAMP="${AUR_TIMESTAMPS[$pkgbase]}"
 
-        # Check if CI_PKGBUILD_TIMESTAMP is set
-        if [ -v "VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_TIMESTAMP]" ]; then
-            local PKGBUILD_TIMESTAMP="${VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_TIMESTAMP]}"
-            if [ "$PKGBUILD_TIMESTAMP" != "$NEW_TIMESTAMP" ]; then
-                update_via_git VARIABLES_UPDATE_PKGBUILD "$git_url"
-                UTIL_UPDATE_AUR_TIMESTAMP VARIABLES_UPDATE_PKGBUILD "$NEW_TIMESTAMP"
-            fi
-        else
-            update_via_git VARIABLES_UPDATE_PKGBUILD "$git_url"
-            UTIL_UPDATE_AUR_TIMESTAMP VARIABLES_UPDATE_PKGBUILD "$NEW_TIMESTAMP"
-        fi
-    fi
+		# Check if CI_PKGBUILD_TIMESTAMP is set
+		if [ -v "VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_TIMESTAMP]" ]; then
+			local PKGBUILD_TIMESTAMP="${VARIABLES_UPDATE_PKGBUILD[CI_PKGBUILD_TIMESTAMP]}"
+			if [ "$PKGBUILD_TIMESTAMP" != "$NEW_TIMESTAMP" ]; then
+				update_via_git VARIABLES_UPDATE_PKGBUILD "$git_url"
+				UTIL_UPDATE_AUR_TIMESTAMP VARIABLES_UPDATE_PKGBUILD "$NEW_TIMESTAMP"
+			fi
+		else
+			update_via_git VARIABLES_UPDATE_PKGBUILD "$git_url"
+			UTIL_UPDATE_AUR_TIMESTAMP VARIABLES_UPDATE_PKGBUILD "$NEW_TIMESTAMP"
+		fi
+	fi
 }
 
 function update_vcs() {
-    local -n VARIABLES_UPDATE_VCS=${1:-VARIABLES}
-    local pkgbase="${VARIABLES_UPDATE_VCS[PKGBASE]}"
+	local -n VARIABLES_UPDATE_VCS=${1:-VARIABLES}
+	local pkgbase="${VARIABLES_UPDATE_VCS[PKGBASE]}"
 
-    # Check if pkgbase ends with -git or if CI_GIT_COMMIT is set
-    if [[ "$pkgbase" != *-git ]] && [ ! -v "VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]" ]; then
-        return 0
-    fi
+	# Check if pkgbase ends with -git or if CI_GIT_COMMIT is set
+	if [[ "$pkgbase" != *-git ]] && [ ! -v "VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]" ]; then
+		return 0
+	fi
 
-    local _NEWEST_COMMIT
-    if ! _NEWEST_COMMIT="$(UTIL_FETCH_VCS_COMMIT VARIABLES_UPDATE_VCS)"; then
-        echo "Warning: Could not fetch latest commit for $pkgbase via heuristic." >&2
-        return 0
-    fi
+	local _NEWEST_COMMIT
+	if ! _NEWEST_COMMIT="$(UTIL_FETCH_VCS_COMMIT VARIABLES_UPDATE_VCS)"; then
+		echo "Warning: Could not fetch latest commit for $pkgbase via heuristic." >&2
+		return 0
+	fi
 
-    if [ -z "$_NEWEST_COMMIT" ]; then
-        unset "VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]"
-        return 0
-    fi
+	if [ -z "$_NEWEST_COMMIT" ]; then
+		unset "VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]"
+		return 0
+	fi
 
-    # Check if CI_GIT_COMMIT is set
-    if [ -v "VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]" ]; then
-        local CI_GIT_COMMIT="${VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]}"
-        if [ "$CI_GIT_COMMIT" != "$_NEWEST_COMMIT" ]; then
-            UTIL_UPDATE_VCS_COMMIT VARIABLES_UPDATE_VCS "$_NEWEST_COMMIT"
-        fi
-    else
-        UTIL_UPDATE_VCS_COMMIT VARIABLES_UPDATE_VCS "$_NEWEST_COMMIT"
-    fi
+	# Check if CI_GIT_COMMIT is set
+	if [ -v "VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]" ]; then
+		local CI_GIT_COMMIT="${VARIABLES_UPDATE_VCS[CI_GIT_COMMIT]}"
+		if [ "$CI_GIT_COMMIT" != "$_NEWEST_COMMIT" ]; then
+			UTIL_UPDATE_VCS_COMMIT VARIABLES_UPDATE_VCS "$_NEWEST_COMMIT"
+		fi
+	else
+		UTIL_UPDATE_VCS_COMMIT VARIABLES_UPDATE_VCS "$_NEWEST_COMMIT"
+	fi
 }
 
 # Collect last modified timestamps from AUR in an efficient way
 collect_aur_timestamps AUR_TIMESTAMPS
 
+# Check which shared libs were updated since last run
+check_library_bumps LIB_VERSIONS_NEW
+
 mkdir "$TMPDIR/aur-pulls"
 
 # Loop through all packages to check if they need to be updated
 for package in "${PACKAGES[@]}"; do
-    unset VARIABLES
-    declare -A VARIABLES
-    if UTIL_READ_MANAGED_PACAKGE "$package" VARIABLES; then
-        update_pkgbuild VARIABLES
-        update_vcs VARIABLES
-        UTIL_WRITE_KNOWN_VARIABLES_TO_FILE "./${package}/.CI/config" VARIABLES
+	unset VARIABLES
+	declare -A VARIABLES
+	if UTIL_READ_MANAGED_PACAKGE "$package" VARIABLES; then
+		update_pkgbuild VARIABLES
+		update_vcs VARIABLES
+		do_lib_bump VARIABLES
 
-        if ! git diff --exit-code --quiet; then
-            if [[ -v VARIABLES[CI_REQUIRES_REVIEW] ]] && [ "${VARIABLES[CI_REQUIRES_REVIEW]}" == "true" ]; then
-                .ci/create-pr.sh "$package"
-            else
-                git add .
-                if [ "$COMMIT" == "false" ]; then
-                    COMMIT=true
-                    [ -v GITLAB_CI ] && git commit -m "chore(packages): update packages"
-                    [ -v GITHUB_ACTIONS ] && git commit -m "chore(packages): update packages [skip ci]"
-                else
-                    git commit --amend --no-edit
-                fi
-                MODIFIED_PACKAGES+=("$package")
-                if [ -v CI_HUMAN_REVIEW ] && [ "$CI_HUMAN_REVIEW" == "true" ] && git show-ref --quiet "origin/update-$package"; then
-                    DELETE_BRANCHES+=("update-$package")
-                fi
-            fi
-        fi
-    fi
+		UTIL_WRITE_KNOWN_VARIABLES_TO_FILE "./${package}/.CI/config" VARIABLES
+
+		if ! git diff --exit-code --quiet; then
+			if [[ -v VARIABLES[CI_REQUIRES_REVIEW] ]] && [ "${VARIABLES[CI_REQUIRES_REVIEW]}" == "true" ]; then
+				.ci/create-pr.sh "$package"
+			else
+				git add .
+				if [ "$COMMIT" == "false" ]; then
+					COMMIT=true
+					[ -v GITLAB_CI ] && git commit -m "chore(packages): update packages"
+					[ -v GITHUB_ACTIONS ] && git commit -m "chore(packages): update packages [skip ci]"
+				else
+					git commit --amend --no-edit
+				fi
+				MODIFIED_PACKAGES+=("$package")
+				if [ -v CI_HUMAN_REVIEW ] && [ "$CI_HUMAN_REVIEW" == "true" ] && git show-ref --quiet "origin/update-$package"; then
+					DELETE_BRANCHES+=("update-$package")
+				fi
+			fi
+		fi
+	fi
 done
 
+# Write back the new library versions
+if [[ ${#NEEDS_BUMP[@]} != 0 ]]; then
+	true >.ci/lib-versions
+	for i in "${!LIB_VERSIONS_NEW[@]}"; do
+		echo "${i/_new/}=${LIB_VERSIONS_NEW[$i]}" >>.ci/lib-versions
+	done
+fi
+
 if [ ${#MODIFIED_PACKAGES[@]} -ne 0 ]; then
-    .ci/schedule-packages.sh schedule "${MODIFIED_PACKAGES[@]}"
+	.ci/schedule-packages.sh schedule "${MODIFIED_PACKAGES[@]}"
 fi
 
 if [ "$COMMIT" = true ]; then
-    git tag -f scheduled
-    git_push_args=()
-    for branch in "${DELETE_BRANCHES[@]}"; do
-        git_push_args+=(":$branch")
-    done
-    [ -v GITLAB_CI ] && git_push_args+=("-o" "ci.skip")
-    git push --atomic origin HEAD:main +refs/tags/scheduled "${git_push_args[@]}"
+	git tag -f scheduled
+	git_push_args=()
+	for branch in "${DELETE_BRANCHES[@]}"; do
+		git_push_args+=(":$branch")
+	done
+	[ -v GITLAB_CI ] && git_push_args+=("-o" "ci.skip")
+	git push --atomic origin HEAD:main +refs/tags/scheduled "${git_push_args[@]}"
 fi

--- a/.ci/schedule-packages.sh
+++ b/.ci/schedule-packages.sh
@@ -14,81 +14,81 @@ PACKAGES=("$@")
 source .ci/util.shlib
 
 if [ -v "PACKAGES[0]" ] && [ "${PACKAGES[0]}" == "all" ] && [ "$COMMAND" == "schedule" ]; then
-    echo "Rebuild of all packages requested."
-    UTIL_GET_PACKAGES PACKAGES
+	echo "Rebuild of all packages requested."
+	UTIL_GET_PACKAGES PACKAGES
 fi
 
 declare -a PARAMS
 if [ "$COMMAND" == "auto-repo-remove" ]; then
-    UTIL_GET_PACKAGES PACKAGES
-    PARAMS+=("auto-repo-remove" "--repo=$REPO_NAME")
+	UTIL_GET_PACKAGES PACKAGES
+	PARAMS+=("auto-repo-remove" "--repo=$REPO_NAME")
 elif [ "$COMMAND" == "schedule" ]; then
-    PARAMS+=("schedule" "--repo=$REPO_NAME")
+	PARAMS+=("schedule" "--repo=$REPO_NAME")
 else
-    echo "Unknown command: $COMMAND"
-    exit 1
+	echo "Unknown command: $COMMAND"
+	exit 1
 fi
 
 # Check if the array of packages is empty
 if [ ${#PACKAGES[@]} -eq 0 ]; then
-    echo "No packages selected."
-    exit 0
+	echo "No packages selected."
+	exit 0
 fi
 
 # Check if running on gitlab
 if [ -v GITLAB_CI ]; then
-    PARAMS+=("--commit")
-    PARAMS+=("${CI_COMMIT_SHA}:${CI_PIPELINE_ID}")
+	PARAMS+=("--commit")
+	PARAMS+=("${CI_COMMIT_SHA}:${CI_PIPELINE_ID}")
 elif [ -v GITHUB_ACTIONS ]; then
-    echo "Warning: Pipeline updates are not supported on GitHub Actions yet."
+	echo "Warning: Pipeline updates are not supported on GitHub Actions yet."
 fi
 
 function generate_deptree() {
-    declare -a ALL_PACKAGES
-    UTIL_GET_PACKAGES ALL_PACKAGES
-    local deptree=""
+	declare -a ALL_PACKAGES
+	UTIL_GET_PACKAGES ALL_PACKAGES
+	local deptree=""
 
-    for i in "${ALL_PACKAGES[@]}"; do
-        local PKGNAMES="" DEPS=""
-        if [ -f "$i/.SRCINFO" ]; then
-            local AWK_OUTPUT
-            if ! AWK_OUTPUT=$(awk -f .ci/awk/get-deps.awk "$i/.SRCINFO"); then
-                continue
-            fi
-            read -r PKGNAMES DEPS <<<"$AWK_OUTPUT"
-        fi
-        if [ -n "$deptree" ]; then
-            deptree+=";"
-        fi
-        deptree+="$i:$PKGNAMES:$DEPS"
-    done
-    echo "$deptree"
+	for i in "${ALL_PACKAGES[@]}"; do
+		local PKGNAMES="" DEPS=""
+		if [ -f "$i/.SRCINFO" ]; then
+			local AWK_OUTPUT
+			if ! AWK_OUTPUT=$(awk -f .ci/awk/get-deps.awk "$i/.SRCINFO"); then
+				continue
+			fi
+			read -r PKGNAMES DEPS <<<"$AWK_OUTPUT"
+		fi
+		if [ -n "$deptree" ]; then
+			deptree+=";"
+		fi
+		deptree+="$i:$PKGNAMES:$DEPS"
+	done
+	echo "$deptree"
 }
 
 if [ "$COMMAND" == "schedule" ]; then
-    PARAMS+=("--deptree")
-    PARAMS+=("$(generate_deptree)")
-    # Prepend the source repo name to each package name and push to PARAMS
-    for i in "${!PACKAGES[@]}"; do
-        PARAMS+=("${BUILD_REPO}:${PACKAGES[$i]}")
-    done
+	PARAMS+=("--deptree")
+	PARAMS+=("$(generate_deptree)")
+	# Prepend the source repo name to each package name and push to PARAMS
+	for i in "${!PACKAGES[@]}"; do
+		PARAMS+=("${BUILD_REPO}:${PACKAGES[$i]}")
+	done
 elif [ "$COMMAND" == "auto-repo-remove" ]; then
-    PARAMS+=("${PACKAGES[@]}")
+	PARAMS+=("${PACKAGES[@]}")
 fi
 
 if [ ! -f .ci/schedule-params.txt ]; then
-    # Write necessary redis variables to file .ci/schedule-redis.txt
-    for key in "REDIS_SSH_HOST" "REDIS_SSH_PORT" "REDIS_SSH_USER" "REDIS_PORT"; do
-        declare -p "$key" >>.ci/schedule-params.txt
-    done
+	# Write necessary redis variables to file .ci/schedule-redis.txt
+	for key in "REDIS_SSH_HOST" "REDIS_SSH_PORT" "REDIS_SSH_USER" "REDIS_PORT"; do
+		declare -p "$key" >>.ci/schedule-params.txt
+	done
 fi
 
 if [ "$COMMAND" == "auto-repo-remove" ]; then
-    declare -a PARAMS_AUTOREPOREMOVE
-    PARAMS_AUTOREPOREMOVE=("${PARAMS[@]}")
-    declare -p PARAMS_AUTOREPOREMOVE >>.ci/schedule-params.txt
+	declare -a PARAMS_AUTOREPOREMOVE
+	PARAMS_AUTOREPOREMOVE=("${PARAMS[@]}")
+	declare -p PARAMS_AUTOREPOREMOVE >>.ci/schedule-params.txt
 elif [ "$COMMAND" == "schedule" ]; then
-    declare -a PARAMS_SCHEDULE
-    PARAMS_SCHEDULE=("${PARAMS[@]}")
-    declare -p PARAMS_SCHEDULE >>.ci/schedule-params.txt
+	declare -a PARAMS_SCHEDULE
+	PARAMS_SCHEDULE=("${PARAMS[@]}")
+	declare -p PARAMS_SCHEDULE >>.ci/schedule-params.txt
 fi

--- a/.ci/update-template.sh
+++ b/.ci/update-template.sh
@@ -8,15 +8,15 @@ CURRENT_REV="$(git rev-parse --abbrev-ref HEAD)"
 
 # CI specific stuff
 if [ -v GITLAB_CI ]; then
-    CI_RSYNC_ARGS=("--include" ".gitlab-ci.yml")
-    CI_COMMIT_MSG=("-m" "chore(ci): update CI from template")
-    CI_PUSH_ARGS=("-o" "ci.skip")
+	CI_RSYNC_ARGS=("--include" ".gitlab-ci.yml")
+	CI_COMMIT_MSG=("-m" "chore(ci): update CI from template")
+	CI_PUSH_ARGS=("-o" "ci.skip")
 elif [ -v GITHUB_ACTIONS ]; then
-    CI_RSYNC_ARGS=("--include" ".github"
-        "--include" ".github/workflows"
-        "--include" ".github/workflows/chaotic-on-commit.yml"
-        "--include" ".github/workflows/chaotic-on-schedule.yml")
-    CI_COMMIT_MSG=("-m" "chore(ci): update CI from template [skip ci]")
+	CI_RSYNC_ARGS=("--include" ".github"
+		"--include" ".github/workflows"
+		"--include" ".github/workflows/chaotic-on-commit.yml"
+		"--include" ".github/workflows/chaotic-on-schedule.yml")
+	CI_COMMIT_MSG=("-m" "chore(ci): update CI from template [skip ci]")
 fi
 
 git clone --depth=1 "$TEMPLATE_REPO" "$TMPDIR/template" -b "main"
@@ -25,22 +25,22 @@ trap "git reset --hard $CURRENT_REV" ERR
 
 # Generic template files
 rsync -a --delete --exclude ".ci/config" \
-    --include ".ci/***" \
-    "${CI_RSYNC_ARGS[@]}" \
-    --exclude "*" \
-    "$TMPDIR/template/" .
+	--include ".ci/***" \
+	"${CI_RSYNC_ARGS[@]}" \
+	--exclude "*" \
+	"$TMPDIR/template/" .
 
 if ! git diff --exit-code --quiet; then
-    git add .
-    git commit "${CI_COMMIT_MSG[@]}"
-    # Check if the scheduled tag does not exist or scheduled does not point to HEAD. In which case, the scheduled tag will not be pushed
-    if ! [ "$(git tag -l "scheduled")" ] || [ "$(git rev-parse HEAD^)" != "$(git rev-parse scheduled)" ]; then
-        git push --atomic origin HEAD:main "${CI_PUSH_ARGS[@]}"
-    else
-        git tag -f scheduled
-        git push --atomic origin HEAD:main +refs/tags/scheduled "${CI_PUSH_ARGS[@]}"
-    fi
-    exit 0
+	git add .
+	git commit "${CI_COMMIT_MSG[@]}"
+	# Check if the scheduled tag does not exist or scheduled does not point to HEAD. In which case, the scheduled tag will not be pushed
+	if ! [ "$(git tag -l "scheduled")" ] || [ "$(git rev-parse HEAD^)" != "$(git rev-parse scheduled)" ]; then
+		git push --atomic origin HEAD:main "${CI_PUSH_ARGS[@]}"
+	else
+		git tag -f scheduled
+		git push --atomic origin HEAD:main +refs/tags/scheduled "${CI_PUSH_ARGS[@]}"
+	fi
+	exit 0
 fi
 
 exit 1

--- a/.ci/util.shlib
+++ b/.ci/util.shlib
@@ -1,80 +1,80 @@
 #!/usr/bin/env bash
 
-KNOWN_VARIABLE_LIST=(CI_PKGBUILD_SOURCE CI_GIT_COMMIT CI_PKGBUILD_TIMESTAMP CI_PACKAGE_BUMP CI_ON_TRIGGER)
-declare -A KNOWN_CONFIG_LIST=([BUILD_REPO]="chaotic-aur" [GIT_AUTHOR_EMAIL]="ci@example.com" [GIT_AUTHOR_NAME]="chaotic-aur" [REDIS_SSH_HOST]="localhost" [REDIS_SSH_PORT]="22" [REDIS_SSH_USER]="redis" [REDIS_PORT]="6379" [REPO_NAME]="chaotic-aur" [CI_HUMAN_REVIEW]="false" [TEMPLATE_REPO]="https://github.com/chaotic-cx/chaotic-repository-template" [TEMPLATE_ENABLE_UPDATES]="true")
+KNOWN_VARIABLE_LIST=(CI_PKGBUILD_SOURCE CI_GIT_COMMIT CI_PKGBUILD_TIMESTAMP CI_PACKAGE_BUMP CI_ON_TRIGGER CI_DEP_REBUILD CI_PKGREL)
+declare -A KNOWN_CONFIG_LIST=([BUILD_REPO]="chaotic-aur" [GIT_AUTHOR_EMAIL]="ci@example.com" [GIT_AUTHOR_NAME]="chaotic-aur" [REDIS_SSH_HOST]="localhost" [REDIS_SSH_PORT]="22" [REDIS_SSH_USER]="redis" [REDIS_PORT]="6379" [REPO_NAME]="chaotic-aur" [CI_HUMAN_REVIEW]="false" [TEMPLATE_REPO]="https://github.com/chaotic-cx/chaotic-repository-template" [TEMPLATE_ENABLE_UPDATES]="true" [KNOWN_REBUILD_DEPS]="icu coreutils")
 
 EXCLUDE_FILES=(.CI .git .gitignore)
 
 # Get a list of all the packages in the repo
 function UTIL_GET_PACKAGES() {
-    local -n GET_PACKAGES_ARRAY=${1:-PACKAGES}
-    mapfile -t GET_PACKAGES_ARRAY < <(find . -mindepth 1 -maxdepth 1 -type d -not -path '*/.*' -printf '%P\n')
+	local -n GET_PACKAGES_ARRAY=${1:-PACKAGES}
+	mapfile -t GET_PACKAGES_ARRAY < <(find . -mindepth 1 -maxdepth 1 -type d -not -path '*/.*' -printf '%P\n')
 }
 
 function UTIL_PRUNE_UNKNOWN_VARIABLES() {
-    local -n PRUNE_VARIABLES=${1:-VARIABLES}
-    local -n PRUNE_VARIABLES_KNOWN=${2:-KNOWN_VARIABLE_LIST}
-    for key in "${!PRUNE_VARIABLES[@]}"; do
-        if [[ ! " ${PRUNE_VARIABLES_KNOWN[*]} " == *" ${key} "* ]]; then
-            unset "PRUNE_VARIABLES[$key]"
-        fi
-    done
+	local -n PRUNE_VARIABLES=${1:-VARIABLES}
+	local -n PRUNE_VARIABLES_KNOWN=${2:-KNOWN_VARIABLE_LIST}
+	for key in "${!PRUNE_VARIABLES[@]}"; do
+		if [[ ! " ${PRUNE_VARIABLES_KNOWN[*]} " == *" ${key} "* ]]; then
+			unset "PRUNE_VARIABLES[$key]"
+		fi
+	done
 }
 
 function UTIL_READ_VARIABLES_FROM_FILE() {
-    local file=$1
-    local -n READ_ASSOC_ARRAY=${2:-VARIABLES}
-    while IFS= read -r line || [ -n "$line" ]; do
-        if [[ "$line" =~ ^[[:space:]]*([a-zA-Z0-9_]+)[[:space:]]*=[[:space:]]*(.*)[[:space:]]*$ ]]; then
-            READ_ASSOC_ARRAY["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
-        fi
-    done < "$file"
+	local file=$1
+	local -n READ_ASSOC_ARRAY=${2:-VARIABLES}
+	while IFS= read -r line || [ -n "$line" ]; do
+		if [[ "$line" =~ ^[[:space:]]*([a-zA-Z0-9_]+)[[:space:]]*=[[:space:]]*(.*)[[:space:]]*$ ]]; then
+			READ_ASSOC_ARRAY["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+		fi
+	done <"$file"
 }
 
 function UTIL_WRITE_VARIABLES_TO_FILE() {
-    local file=$1
-    local -n WRITE_ASSOC_ARRAY=${2:-VARIABLES}
+	local file=$1
+	local -n WRITE_ASSOC_ARRAY=${2:-VARIABLES}
 
-    # Clear the file before writing variables
-    true > "$file"
+	# Clear the file before writing variables
+	true >"$file"
 
-    for key in "${!WRITE_ASSOC_ARRAY[@]}"; do
-        echo "$key=${WRITE_ASSOC_ARRAY[$key]}" >> "$file"
-    done
+	for key in "${!WRITE_ASSOC_ARRAY[@]}"; do
+		echo "$key=${WRITE_ASSOC_ARRAY[$key]}" >>"$file"
+	done
 }
 
 # The reason this function doesn't use UTIL_PRUNE_UNKNOWN_VARIABLES is because we want to
 # keep the unknown variables in the array, but not write them to the file
 function UTIL_WRITE_KNOWN_VARIABLES_TO_FILE() {
-    local file=$1
-    local -n WRITE_ASSOC_ARRAY=${2:-VARIABLES}
-    local -n WRITE_ASSOC_ARRAY_KNOWN=${3:-KNOWN_VARIABLE_LIST}
+	local file=$1
+	local -n WRITE_ASSOC_ARRAY=${2:-VARIABLES}
+	local -n WRITE_ASSOC_ARRAY_KNOWN=${3:-KNOWN_VARIABLE_LIST}
 
-    # Clear the file before writing variables
-    true > "$file"
+	# Clear the file before writing variables
+	true >"$file"
 
-    for key in "${!WRITE_ASSOC_ARRAY[@]}"; do
-        if [[ ! " ${WRITE_ASSOC_ARRAY_KNOWN[*]} " == *" ${key} "* ]]; then
-            continue;
-        fi
-        echo "$key=${WRITE_ASSOC_ARRAY[$key]}" >> "$file"
-    done
+	for key in "${!WRITE_ASSOC_ARRAY[@]}"; do
+		if [[ ! " ${WRITE_ASSOC_ARRAY_KNOWN[*]} " == *" ${key} "* ]]; then
+			continue
+		fi
+		echo "$key=${WRITE_ASSOC_ARRAY[$key]}" >>"$file"
+	done
 }
 
 function UTIL_READ_MANAGED_PACAKGE() {
-    local target_file="./${1}/.CI/config"
-    if [ -f "$target_file" ]; then
-        local -n READ_MANAGED_ASSOC_ARRAY=${2:-VARIABLES}
-        UTIL_READ_VARIABLES_FROM_FILE "$target_file" READ_MANAGED_ASSOC_ARRAY
+	local target_file="./${1}/.CI/config"
+	if [ -f "$target_file" ]; then
+		local -n READ_MANAGED_ASSOC_ARRAY=${2:-VARIABLES}
+		UTIL_READ_VARIABLES_FROM_FILE "$target_file" READ_MANAGED_ASSOC_ARRAY
 
-        # Check if any variable at all was read
-        if [ ${#READ_MANAGED_ASSOC_ARRAY[@]} -ne 0 ]; then
-            UTIL_PRUNE_UNKNOWN_VARIABLES READ_MANAGED_ASSOC_ARRAY
-            READ_MANAGED_ASSOC_ARRAY[PKGBASE]="$1"
-            return 0
-        fi
-    fi
-    return 1
+		# Check if any variable at all was read
+		if [ ${#READ_MANAGED_ASSOC_ARRAY[@]} -ne 0 ]; then
+			UTIL_PRUNE_UNKNOWN_VARIABLES READ_MANAGED_ASSOC_ARRAY
+			READ_MANAGED_ASSOC_ARRAY[PKGBASE]="$1"
+			return 0
+		fi
+	fi
+	return 1
 }
 
 # Extract both the normal url and the fragment
@@ -87,165 +87,201 @@ function UTIL_GET_URI_PARTS() {
 	fi
 	fragment=${fragment%\?*}
 
-    local url="${netfile%%#*}"
-    url="${url%%\?*}"
+	local url="${netfile%%#*}"
+	url="${url%%\?*}"
 
 	printf "%s\n%s" "$url" "$fragment"
 }
 
 # $1: VARIABLES
 function UTIL_FETCH_VCS_COMMIT() {
-    local -n VARIABLES_FETCH_VCS_COMMIT=${1:-VARIABLES}
-    local pkgbase="${VARIABLES_FETCH_VCS_COMMIT[PKGBASE]}"
+	local -n VARIABLES_FETCH_VCS_COMMIT=${1:-VARIABLES}
+	local pkgbase="${VARIABLES_FETCH_VCS_COMMIT[PKGBASE]}"
 
-    # Check if .SRCINFO exists. We can't work with a -git package without it
-    if ! [ -f "$pkgbase/.SRCINFO" ]; then
-        return 1
-    fi
+	# Check if .SRCINFO exists. We can't work with a -git package without it
+	if ! [ -f "$pkgbase/.SRCINFO" ]; then
+		return 1
+	fi
 
-    # Parse the first source from the .SRCINFO file
-    # Example output: https://github.com/LinusDierheimer/fastfetch.git#branch=dev
-    local source fragment ref
-    source=$(grep -m 1 -oP '\ssource\s=\s.*git\+\K.*$' "$pkgbase/.SRCINFO" || true)
-    ref=HEAD
+	# Parse the first source from the .SRCINFO file
+	# Example output: https://github.com/LinusDierheimer/fastfetch.git#branch=dev
+	local source fragment ref
+	source=$(grep -m 1 -oP '\ssource\s=\s.*git\+\K.*$' "$pkgbase/.SRCINFO" || true)
+	ref=HEAD
 
-    if [ -z "$source" ]; then
-        # Unable to find source in .SRCINFO
-        # This does not mean that we are at fault
-        # So we return 0 to indicate that we should remove the VCS indication from the package
-        return 0
-    fi
+	if [ -z "$source" ]; then
+		# Unable to find source in .SRCINFO
+		# This does not mean that we are at fault
+		# So we return 0 to indicate that we should remove the VCS indication from the package
+		return 0
+	fi
 
-    IFS=$'\n' read -rd '' source fragment <<< "$(UTIL_GET_URI_PARTS "$source")"
+	IFS=$'\n' read -rd '' source fragment <<<"$(UTIL_GET_URI_PARTS "$source")"
 
-    if [ -n "$fragment" ]; then
-        local type
-        type="${fragment%%=*}"
-        # This heuristic is used to check if the fragment is a branch.
-        # If the fragment is not a branch, it must be a commit hash or a tag.
-        # In those cases, we don't need to update VCS, because we assume
-        # the package maintainer will update the PKGBUILD accordingly.
-        if [ "$type" != "branch" ]; then
-            return 0
-        fi
-        ref="${fragment##*=}"
-    fi
+	if [ -n "$fragment" ]; then
+		local type
+		type="${fragment%%=*}"
+		# This heuristic is used to check if the fragment is a branch.
+		# If the fragment is not a branch, it must be a commit hash or a tag.
+		# In those cases, we don't need to update VCS, because we assume
+		# the package maintainer will update the PKGBUILD accordingly.
+		if [ "$type" != "branch" ]; then
+			return 0
+		fi
+		ref="${fragment##*=}"
+	fi
 
-    local _NEWEST_COMMIT
-    if ! _NEWEST_COMMIT="$(git ls-remote "$source" "$ref" | grep -m1 -oP '\w+(?=\t\w)')"; then
-        return 1
-    fi
-    if [ -z "$_NEWEST_COMMIT" ]; then
-        return 1
-    fi
+	local _NEWEST_COMMIT
+	if ! _NEWEST_COMMIT="$(git ls-remote "$source" "$ref" | grep -m1 -oP '\w+(?=\t\w)')"; then
+		return 1
+	fi
+	if [ -z "$_NEWEST_COMMIT" ]; then
+		return 1
+	fi
 
-    printf "%s" "$_NEWEST_COMMIT"
+	printf "%s" "$_NEWEST_COMMIT"
 }
 
 # $1: VARIABLES
 # $2: new commit
 function UTIL_UPDATE_VCS_COMMIT() {
-    local -n VARIABLES_UPDATE_VCS_COMMIT=${1:-VARIABLES}
-    local new_commit="$2"
+	local -n VARIABLES_UPDATE_VCS_COMMIT=${1:-VARIABLES}
+	local new_commit="$2"
 
-    if [ -n "$new_commit" ]; then
-        VARIABLES_UPDATE_VCS_COMMIT[CI_GIT_COMMIT]="$new_commit"
-    fi
+	if [ -n "$new_commit" ]; then
+		VARIABLES_UPDATE_VCS_COMMIT[CI_GIT_COMMIT]="$new_commit"
+	fi
+}
+
+function UTIL_UPDATE_PKGREL() {
+	local -n VARIABLES_UPDATE_PKGREL=${1:-VARIABLES}
+	local new_pkgrel="$2"
+
+	if [ -n "$new_pkgrel" ]; then
+		VARIABLES_UPDATE_PKGREL[CI_PKGREL]="$new_pkgrel"
+	fi
 }
 
 # $1: Output associative array
 # $2: array of pkgbases on AUR
 function UTIL_FETCH_AUR_TIMESTAMPS() {
-    local -n OUTPUT_ASSOC_ARRAY=$1
-    local pkgbases=()
+	local -n OUTPUT_ASSOC_ARRAY=$1
+	local pkgbases=()
 
-    read -ra pkgbases <<< "$2"
+	read -ra pkgbases <<<"$2"
 
-    # Check size of array
-    if [ ${#pkgbases[@]} -eq 0 ]; then
-        return 0
-    fi
+	# Check size of array
+	if [ ${#pkgbases[@]} -eq 0 ]; then
+		return 0
+	fi
 
-    local API_URL="https://aur.archlinux.org/rpc/v5/info"
-    local first=1
+	local API_URL="https://aur.archlinux.org/rpc/v5/info"
+	local first=1
 
-    # Loop through $2 but via index numbers. If index != 0, append &arg[]= to the URL
-    for i in "${!pkgbases[@]}"; do
-        if [ "$first" -eq 1 ]; then
-            API_URL+="?arg[]=${pkgbases[$i]}"
-            first=0
-        else
-            API_URL+="&arg[]=${pkgbases[$i]}"
-        fi
+	# Loop through $2 but via index numbers. If index != 0, append &arg[]= to the URL
+	for i in "${!pkgbases[@]}"; do
+		if [ "$first" -eq 1 ]; then
+			API_URL+="?arg[]=${pkgbases[$i]}"
+			first=0
+		else
+			API_URL+="&arg[]=${pkgbases[$i]}"
+		fi
 
-        # Every 150 packages or at the end of the array, fetch the timestamps
-        if [ $((i % 150)) -eq 149 ] || [ "$i" -eq "$((${#pkgbases[@]} - 1))" ]; then
-            local response
-            echo "Info: Fetching AUR timestamps for $((i + 1))/${#pkgbases[@]} packages..."
-            if response="$(curl -s "$API_URL")"; then
-                local -a res_timestamps
-                mapfile -t res_timestamps <<< "$(jq -r '.results[].LastModified' <<<"$response")"
-                local -a res_pkgbases
-                mapfile -t res_pkgbases <<< "$(jq -r '.results[].PackageBase' <<<"$response")"
+		# Every 150 packages or at the end of the array, fetch the timestamps
+		if [ $((i % 150)) -eq 149 ] || [ "$i" -eq "$((${#pkgbases[@]} - 1))" ]; then
+			local response
+			echo "Info: Fetching AUR timestamps for $((i + 1))/${#pkgbases[@]} packages..."
+			if response="$(curl -s "$API_URL")"; then
+				local -a res_timestamps
+				mapfile -t res_timestamps <<<"$(jq -r '.results[].LastModified' <<<"$response")"
+				local -a res_pkgbases
+				mapfile -t res_pkgbases <<<"$(jq -r '.results[].PackageBase' <<<"$response")"
 
-                # Loop through timestamps and pkgbases and add them to the associative array
-                for j in "${!res_timestamps[@]}"; do
-                    OUTPUT_ASSOC_ARRAY["${res_pkgbases[$j]}"]="${res_timestamps[$j]}"
-                done
-            fi
-            API_URL="https://aur.archlinux.org/rpc/v5/info"
-            first=1
-        fi
-    done
+				# Loop through timestamps and pkgbases and add them to the associative array
+				for j in "${!res_timestamps[@]}"; do
+					OUTPUT_ASSOC_ARRAY["${res_pkgbases[$j]}"]="${res_timestamps[$j]}"
+				done
+			fi
+			API_URL="https://aur.archlinux.org/rpc/v5/info"
+			first=1
+		fi
+	done
+}
+
+# $1: Output associative array
+# $2: array of pkgbases on Arch repos
+function UTIL_FETCH_ARCH_REPO_VERSIONS() {
+	local pkgbases=()
+	local -n OUTPUT_ASSOC_ARRAY=$1
+	read -ra pkgbases <<<"$2"
+
+	# Check size of array
+	if [ ${#pkgbases[@]} -eq 0 ]; then
+		return 0
+	fi
+
+	local API_URL="https://archlinux.org/packages/core/x86_64"
+
+	# It does not seem to be possible to do optimized calls to the Arch Linux API
+	# therefore just loop through pkgbases and fetch the versions
+	for i in "${!pkgbases[@]}"; do
+		local response
+		if response="$(curl -s "$API_URL/${pkgbases[$i]}/json/")"; then
+			local version
+			version="$(jq -r '.pkgver' <<<"$response")"
+			pkgrel="$(jq -r '.pkgrel' <<<"$response")"
+			OUTPUT_ASSOC_ARRAY["ver_new_${pkgbases[$i]}"]="$version-$pkgrel"
+		fi
+	done
 }
 
 # $1: VARIABLES
 # $2: new timestamp
 function UTIL_UPDATE_AUR_TIMESTAMP() {
-    local -n VARIABLES_AUR_TIMESTAMP=${1:-VARIABLES}
-    local new_timestamp="$2"
+	local -n VARIABLES_AUR_TIMESTAMP=${1:-VARIABLES}
+	local new_timestamp="$2"
 
-    if [ "$new_timestamp" != "0" ]; then
-        VARIABLES_AUR_TIMESTAMP[CI_PKGBUILD_TIMESTAMP]="$new_timestamp"
-    fi
+	if [ "$new_timestamp" != "0" ]; then
+		VARIABLES_AUR_TIMESTAMP[CI_PKGBUILD_TIMESTAMP]="$new_timestamp"
+	fi
 }
 
 # Generate exclude list for rsync, diff, etc.
 # $1: prefix
 # $2: Extra ignores
 function UTIL_GET_EXCLUDE_LIST() {
-    local prefix="$1"
-    local -a extra_ignores=()
-    read -ra extra_ignores <<< "${2:-}"
+	local prefix="$1"
+	local -a extra_ignores=()
+	read -ra extra_ignores <<<"${2:-}"
 
-    local -a exclude_list=("${EXCLUDE_FILES[@]}" "${extra_ignores[@]}")
+	local -a exclude_list=("${EXCLUDE_FILES[@]}" "${extra_ignores[@]}")
 
-    local -a exclude_output=()
-    for i in "${exclude_list[@]}"; do
-        exclude_output+=("${prefix}")
-        exclude_output+=("${i}")
-    done
+	local -a exclude_output=()
+	for i in "${exclude_list[@]}"; do
+		exclude_output+=("${prefix}")
+		exclude_output+=("${i}")
+	done
 
-    printf "%s" "${exclude_output[*]}"
+	printf "%s" "${exclude_output[*]}"
 }
 
 function UTIL_READ_CONFIG_FILE() {
-    local -a UTIL_READ_CONFIG_FILE_KNOWN_VARIABLES=("${!KNOWN_CONFIG_LIST[@]}")
-    declare -A UTIL_READ_CONFIG_FILE_ARRAY
-    UTIL_READ_VARIABLES_FROM_FILE ".ci/config" UTIL_READ_CONFIG_FILE_ARRAY
-    UTIL_PRUNE_UNKNOWN_VARIABLES UTIL_READ_CONFIG_FILE_ARRAY UTIL_READ_CONFIG_FILE_KNOWN_VARIABLES
+	local -a UTIL_READ_CONFIG_FILE_KNOWN_VARIABLES=("${!KNOWN_CONFIG_LIST[@]}")
+	declare -A UTIL_READ_CONFIG_FILE_ARRAY
+	UTIL_READ_VARIABLES_FROM_FILE ".ci/config" UTIL_READ_CONFIG_FILE_ARRAY
+	UTIL_PRUNE_UNKNOWN_VARIABLES UTIL_READ_CONFIG_FILE_ARRAY UTIL_READ_CONFIG_FILE_KNOWN_VARIABLES
 
-    # Set all variables as global variables
-    for key in "${!UTIL_READ_CONFIG_FILE_ARRAY[@]}"; do
-        declare -g "$key=${UTIL_READ_CONFIG_FILE_ARRAY[$key]}"
-        export "$key"
-    done
+	# Set all variables as global variables
+	for key in "${!UTIL_READ_CONFIG_FILE_ARRAY[@]}"; do
+		declare -g "$key=${UTIL_READ_CONFIG_FILE_ARRAY[$key]}"
+		export "$key"
+	done
 
-    # Set any missing variables to their default values
-    for key in "${!KNOWN_CONFIG_LIST[@]}"; do
-        if ! [ -v "$key" ]; then
-            declare -g "$key=${KNOWN_CONFIG_LIST[$key]}"
-            export "$key"
-        fi
-    done
+	# Set any missing variables to their default values
+	for key in "${!KNOWN_CONFIG_LIST[@]}"; do
+		if ! [ -v "$key" ]; then
+			declare -g "$key=${KNOWN_CONFIG_LIST[$key]}"
+			export "$key"
+		fi
+	done
 }


### PR DESCRIPTION
This works by maintaining a list of current package versions. Currently, only packages from the core repo can be checked for updated versions.

TODO: fix comparison of versions using dynamically generated variable names. I did not find out how to do this. The idea is to read the lib_versions file, resulting in variables like ver_coreutils. The loop has variables like new_ver_coreutils and I want it to compare against the current value, derived from $package.