### PR TITLE
feat(scheduler): supply a --versions parameter

### DIFF
--- a/.ci/schedule-packages.sh
+++ b/.ci/schedule-packages.sh
@@ -66,9 +66,29 @@ function generate_deptree() {
     echo "$deptree"
 }
 
+function generate_versions() {
+    set -euo pipefail
+    local VERSIONS=""
+    for i in "${PACKAGES[@]}"; do
+        local PKGVER
+        PKGVER=$(awk -F "= " '/pkgver/ {print $2}' "$i/.SRCINFO")
+        PKGREL=$(awk -F "= " '/pkgrel/ {print $2}' "$i/.SRCINFO")
+
+        # Although unlikely, better be sure to not have any colons in the version
+        if [[ $PKGVER == *":"* ]]; then
+            PKGVER=$(echo "$PKGVER" | cut -d ":" -f 2)
+        fi
+
+        VERSIONS+="$i:$PKGVER-$PKGREL;"
+    done
+    echo "$VERSIONS"
+}
+
 if [ "$COMMAND" == "schedule" ]; then
     PARAMS+=("--deptree")
     PARAMS+=("$(generate_deptree)")
+    PARAMS+=("--versions")
+    PARAMS+=("$(generate_versions)")
     PARAMS+=("${PACKAGES[@]}")
 elif [ "$COMMAND" == "auto-repo-remove" ]; then
     PARAMS+=("${PACKAGES[@]}")


### PR DESCRIPTION
This will be parsed by chaotic manager to output version information to the notifier (eg. updated package X to version Y). There is currently no way to determine a package's version easily.

Outputs parameters like `--versions calamares-garuda:3.3.6.r29.g2e9618440-3;bluetooth-support:1-7;calamares-branding-garuda:r49.ddc718d-1;`