### PR TITLE
Revert commit history shrinking compromise features

### DIFF
--- a/.ci/config
+++ b/.ci/config
@@ -22,6 +22,6 @@ CI_CLONE_DELAY="0"
 # Proxy to use for AUR requests
 CI_AUR_PROXY=""
 # Archlinux / Chaotic-AUR repo mirror to use for pulling db files from
-CI_LIB_DB="https://arch.mirror.constant.com/core/os/x86_64/core.db https://arch.mirror.constant.com/community/os/x86_64/community.db https://arch.mirror.constant.com/extra/os/x86_64/extra.db"
+CI_LIB_DB="https://arch.mirror.constant.com/core/os/x86_64/core.db https://arch.mirror.constant.com/extra/os/x86_64/extra.db"
 # Exit code indicating an intentional build skip (for pipeline status)
 CI_CODE_SKIP=123

--- a/.ci/config
+++ b/.ci/config
@@ -15,8 +15,6 @@ CI_HUMAN_REVIEW="false"
 # This should be set to true in case select AUR repositories should be managed by CI
 # a fitting SSH key needs to be deployed as AUR_KEY via secret CI variable
 CI_MANAGE_AUR="false"
-# If we should overwrite existing automated commits to reduce the size of the git history
-CI_OVERWRITE_COMMITS="true"
 # How long to wait between every executed git clone command for ratelimits
 CI_CLONE_DELAY="0"
 # Proxy to use for AUR requests

--- a/.ci/on-commit.sh
+++ b/.ci/on-commit.sh
@@ -116,21 +116,6 @@ if [ ${#PACKAGES[@]} -eq 0 ] && [ "$PACKAGE_REMOVED" = false ]; then
     UTIL_PRINT_INFO "No packages to build, exiting gracefully."
 else
     if [ ${#PACKAGES[@]} -ne 0 ]; then
-        # Maintain the state
-        if git show-ref --quiet "origin/state"; then
-            git config --global user.name "$GIT_AUTHOR_NAME"
-            git config --global user.email "$GIT_AUTHOR_EMAIL"
-
-            git worktree add .state state
-            pushd .state >/dev/null
-            rm  -f "${!PACKAGES[@]}"
-            popd >/dev/null
-            git -C .state add -A
-            git -C .state commit -q --amend --no-edit
-
-            git_push_args+=("state")
-        fi
-
         # Check if we have to build all packages
         if [[ -v "PACKAGES[all]" ]]; then
             .ci/schedule-packages.sh schedule all

--- a/.ci/on-schedule.sh
+++ b/.ci/on-schedule.sh
@@ -40,7 +40,7 @@ git config --global user.email "$GIT_AUTHOR_EMAIL"
 git config --global init.defaultBranch "master"
 
 if [ -v TEMPLATE_ENABLE_UPDATES ] && [ "$TEMPLATE_ENABLE_UPDATES" == "true" ]; then
-    .ci/update-template.sh && UTIL_PRINT_INFO "Updated CI template." && exit 0 || true
+    { .ci/update-template.sh && UTIL_PRINT_INFO "Updated CI template." && exit 0; } || true
 fi
 
 # Check if the scheduled tag does not exist or scheduled does not point to HEAD
@@ -57,22 +57,8 @@ declare -A CHANGED_LIBS=()
 DELETE_BRANCHES=()
 UTIL_GET_PACKAGES PACKAGES
 COMMIT="${COMMIT:-false}"
-PUSH=false
-
-# Manage the .state worktree to confine the state of packages to a separate branch
-# The goal is to keep the commit history clean
-function manage_state() {
-    if git show-ref --quiet "origin/state"; then
-        git worktree add .state origin/state --detach -q
-        # We have to make sure that the commit is still in the history of the state branch
-        # Otherwise, this implies a force push happened. We need to re-create the state from scratch.
-        if [ ! -f .state/.commit ] || ! git branch --contains "$(cat .state/.commit)" &>/dev/null; then
-            git worktree remove .state
-        fi
-    fi
-    git worktree add .newstate -B state --orphan -q
-}
-
+# Signals if the .ci/version-state file has already been comitted or not
+VERSION_STATE_UPDATED=false
 
 # Loop through all packages to do optimized aur RPC calls
 # $1 = Output associative array
@@ -105,13 +91,13 @@ function collect_changed_libs() {
     if [ -z "$CI_LIB_DB" ]; then
         return 0
     fi
-    if [ ! -f .state/versions ]; then
-        mkdir -p .state || true
-        touch .state/versions
+    if [ ! -f .ci/version-state ]; then
+        touch .ci/version-state
     fi
 
     IFS=' ' read -r -a link_array <<<"${CI_LIB_DB//\"/}"
 
+    local _TEMP_LIB
     _TEMP_LIB="$(mktemp -d)"
 
     for repo in "${link_array[@]}"; do
@@ -119,16 +105,40 @@ function collect_changed_libs() {
     done
 
     # Sort versions file in-place because comm requires it
-    sort -o "${_TEMP_LIB}/versions.new"{,}
-    comm -23 .state/versions "${_TEMP_LIB}/versions.new" >"$_TEMP_LIB/versions.diff"
+    sort -o "${_TEMP_LIB}/version-state"{,}
+    comm -13 .ci/version-state "${_TEMP_LIB}/version-state" >"$_TEMP_LIB/versions.diff"
 
     while IFS= read -r line; do
         IFS=':' read -r -a pkg <<<"$line"
         CHANGED_LIBS["${pkg[0]}"]="true"
     done <"$_TEMP_LIB/versions.diff"
+
+    mv "${_TEMP_LIB}/version-state" .ci/version-state
+    rm -rf "$_TEMP_LIB"
+}
+
+function generate-commit() {
+    set -euo pipefail
+    if [ "$COMMIT" == "false" ]; then
+        COMMIT=true
+        if [ -v GITLAB_CI ]; then git commit -q -m "chore(packages): update packages"; fi
+        if [ -v GITHUB_ACTIONS ]; then git commit -q -m "chore(packages): update packages [skip ci]"; fi
+    else
+        git commit -q --amend --no-edit --date=now
+    fi
+}
+
+function save-version-state() {
+    set -euo pipefail
+    if [ "$VERSION_STATE_UPDATED" == "false" ]; then
+        git add .ci/version-state
+        generate-commit
+        VERSION_STATE_UPDATED=true
+    fi
 }
 
 function update-lib-bump() {
+    set -euo pipefail
     local bump=0
     local -n pkg_config=${1:-VARIABLES}
 
@@ -137,7 +147,7 @@ function update-lib-bump() {
     fi
 
     # Split the string on : into an array
-    IFS=':' read -r -a LIBS <<<"${CONFIG[CI_REBUILD_TRIGGERS]}"
+    IFS=':' read -r -a LIBS <<<"${pkg_config[CI_REBUILD_TRIGGERS]}"
     for library in "${LIBS[@]}"; do
         if [[ -v CHANGED_LIBS["$library"] ]]; then
             bump=1
@@ -146,24 +156,33 @@ function update-lib-bump() {
     done
 
     if [ $bump -eq 1 ]; then
-        UTIL_PRINT_INFO "Bumping pkgrel of $package because of a detected library mismatch"
-        
-        local _PKGVER _BUMPCOUNT _PKGVER_IN_DB
-        # Example format: 1:1.2.3-1/1 or 1.2.3
-        # Split at slash, but if it doesnt exist, set it to 1
-        _PKGVER="${CONFIG[CI_PACKAGE_BUMP]%%/*}"
-        _BUMPCOUNT="${CONFIG[CI_PACKAGE_BUMP]#*/}"
-        _PKGVER_IN_DB=$(grep "$package:" "${_TEMP_LIB}/versions.new" | cut -d ":" -f 2)
+        save-version-state
+        UTIL_PRINT_INFO "$package: Bumping pkgrel of $package because of a detected library version change"
 
-        if [[ "${_BUMPCOUNT}" == "${CONFIG[CI_PACKAGE_BUMP]}" ]]; then
+        local _PKGVER _BUMPCOUNT _PKGVER_IN_DB
+        _PKGVER_IN_DB="$(grep "^$package:" ".ci/version-state" | cut -d ":" -f 2 || true)"
+
+        if [ -z "$_PKGVER_IN_DB" ]; then
+            UTIL_PRINT_WARNING "$package: Could not find package version in the version-state file."
+            return 0
+        fi
+
+        if [[ -v pkg_config[CI_PACKAGE_BUMP] ]]; then
+            _PKGVER="${pkg_config[CI_PACKAGE_BUMP]%%/*}"
+            _BUMPCOUNT="${pkg_config[CI_PACKAGE_BUMP]#*/}"
+
+            # If the version we except matches the version in the database
+            if [ "$(vercmp "${_PKGVER}" "${_PKGVER_IN_DB}")" = "0" ]; then
+                # Increment the bump count
+                _BUMPCOUNT=$(( _BUMPCOUNT + 1 ))
+            else
+                # Otherwise, set the bump count to 1
+                _BUMPCOUNT=1
+            fi
+        else
             _BUMPCOUNT=1
         fi
-
-        if [ "$(vercmp "${_PKGVER}" "${_PKGVER_IN_DB}")" = "0" ]; then
-            pkg_config[CI_PACKAGE_BUMP]="$_PKGVER_IN_DB/$_BUMPCOUNT"
-        else 
-            pkg_config[CI_PACKAGE_BUMP]=""
-        fi
+        pkg_config[CI_PACKAGE_BUMP]="$_PKGVER_IN_DB/$_BUMPCOUNT"
     fi
 }
 
@@ -382,10 +401,6 @@ function update_vcs() {
     fi
 }
 
-# Create .state and .newstate worktrees
-manage_state
-
-
 # Collect last modified timestamps from AUR in an efficient way
 collect_aur_timestamps AUR_TIMESTAMPS
 
@@ -411,8 +426,6 @@ for package in "${PACKAGES[@]}"; do
     if ! git diff --exit-code --quiet -- "$package"; then
         # shellcheck disable=SC2102
         if [[ -v VARIABLES[CI_REQUIRES_REVIEW] ]] && [ "${VARIABLES[CI_REQUIRES_REVIEW]}" == "true" ]; then
-            # The updated state of the package will still be written to the state branch, even if the main content goes onto the PR branch
-            # This is okay, because merging the PR branch will trigger a build, so that behavior is expected and prevents a double execution
             if [ "$COMMIT" == "false" ]; then
                 .ci/create-pr.sh "$package" false
             else
@@ -420,59 +433,36 @@ for package in "${PACKAGES[@]}"; do
                 # This is because there is a very high chance this current commit will be amended
                 .ci/create-pr.sh "$package" true
             fi
-            PUSH=true
         else
             git add "$package"
-            if [ "$COMMIT" == "false" ]; then
-                COMMIT=true
-                [ -v GITLAB_CI ] && git commit -q -m "chore(packages): update packages"
-                [ -v GITHUB_ACTIONS ] && git commit -q -m "chore(packages): update packages [skip ci]"
-            else
-                git commit -q --amend --no-edit --date=now
-            fi
-            PUSH=true
+            generate-commit
 
-            # We don't want to schedule packages that have a specific trigger to prevent 
+            # We don't want to schedule packages that have a specific trigger to prevent
             # large packages getting scheduled too often and wasting resources (e.g. llvm-git)
-            if [[ ${VARIABLES[CI_ON_TRIGGER]+x} ]]; then 
+            if [[ ${VARIABLES[CI_ON_TRIGGER]+x} ]]; then
                 UTIL_PRINT_INFO "Will not schedule $package because it has trigger ${VARIABLES[CI_ON_TRIGGER]} set."
-            else 
+            else
                 MODIFIED_PACKAGES+=("$package")
-            fi 
+            fi
 
             if [ -v CI_HUMAN_REVIEW ] && [ "$CI_HUMAN_REVIEW" == "true" ] && git show-ref --quiet "origin/update-$package"; then
                 DELETE_BRANCHES+=("update-$package")
             fi
         fi
-    # We also need to check the worktree for changes, because we might have an updated git hash
-    elif ! UTIL_CHECK_STATE_DIFF "$package"; then
-        MODIFIED_PACKAGES+=("$package")
     fi
 done
-
-# Update the lib versions state file
-if [ $PUSH == true ]; then
-    mv "$_TEMP_LIB/versions.new" .newstate/versions
-    git add .newstate/versions
-    git commit -q --amend --no-edit --date=now
-fi
-
-git rev-parse HEAD >.newstate/.commit
-git -C .newstate add -A
-git -C .newstate commit -q -m "chore(state): update state" --allow-empty
 
 if [ ${#MODIFIED_PACKAGES[@]} -ne 0 ]; then
     .ci/schedule-packages.sh schedule "${MODIFIED_PACKAGES[@]}"
     .ci/manage-aur.sh "${MODIFIED_PACKAGES[@]}"
 fi
 
-if [ "$PUSH" = true ]; then
+if [ "$COMMIT" = true ]; then
     git tag -f scheduled
     git_push_args=()
     for branch in "${DELETE_BRANCHES[@]}"; do
         git_push_args+=(":$branch")
     done
     [ -v GITLAB_CI ] && git_push_args+=("-o" "ci.skip")
-    [ "$COMMIT" == "force" ] && git_push_args+=("--force-with-lease=main")
-    git push --atomic origin HEAD:main +state +refs/tags/scheduled "${git_push_args[@]}"
+    git push --atomic origin HEAD:main +refs/tags/scheduled "${git_push_args[@]}"
 fi

--- a/.ci/on-schedule.sh
+++ b/.ci/on-schedule.sh
@@ -73,20 +73,6 @@ function manage_state() {
     git worktree add .newstate -B state --orphan -q
 }
 
-# Check if the current commit is already an automatic commit
-# If it is, check if we should overwrite it
-function manage_commit() {
-    if [ -v CI_OVERWRITE_COMMITS ] && [ "$CI_OVERWRITE_COMMITS" == "true" ]; then
-        local COMMIT_MSG=""
-        local REGEX="^chore\(packages\): update packages( \[skip ci\])?$"
-        if COMMIT_MSG="$(git log -1 --pretty=%s)"; then
-            if [[ "$COMMIT_MSG" =~ $REGEX ]]; then
-                # Signal that we should not only append to the commit, but also force push the branch
-                COMMIT=force
-            fi
-        fi
-    fi
-}
 
 # Loop through all packages to do optimized aur RPC calls
 # $1 = Output associative array
@@ -399,8 +385,6 @@ function update_vcs() {
 # Create .state and .newstate worktrees
 manage_state
 
-# Reduce history pollution from automatic commits
-manage_commit
 
 # Collect last modified timestamps from AUR in an efficient way
 collect_aur_timestamps AUR_TIMESTAMPS

--- a/.ci/update-template.sh
+++ b/.ci/update-template.sh
@@ -24,7 +24,7 @@ git clone --depth=1 "$TEMPLATE_REPO" "$TMPDIR/template" -b "main" -q
 trap "git reset --hard $CURRENT_REV" ERR
 
 # Generic template files
-rsync -a --delete --exclude ".ci/config" \
+rsync -a --delete --exclude ".ci/config" --exclude ".ci/version-state" \
     --include ".ci/***" \
     "${CI_RSYNC_ARGS[@]}" \
     --exclude "*" \

--- a/.ci/util.shlib
+++ b/.ci/util.shlib
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=2034
 
-KNOWN_VARIABLE_LIST=(CI_PKGBUILD_SOURCE CI_PACKAGE_BUMP CI_ON_TRIGGER CI_MANAGE_AUR BUILDER_CACHE_SOURCES BUILDER_EXTRA_TIMEOUT CI_REBUILD_TRIGGERS)
-KNOWN_STATE_VARIABLE_LIST=(CI_GIT_COMMIT CI_PKGBUILD_TIMESTAMP)
+KNOWN_VARIABLE_LIST=(CI_PKGBUILD_SOURCE CI_PACKAGE_BUMP CI_ON_TRIGGER CI_MANAGE_AUR BUILDER_CACHE_SOURCES BUILDER_EXTRA_TIMEOUT CI_REBUILD_TRIGGERS CI_GIT_COMMIT CI_PKGBUILD_TIMESTAMP)
 declare -A KNOWN_CONFIG_LIST=([BUILD_REPO]="chaotic-aur" [GIT_AUTHOR_EMAIL]="ci@example.com" [GIT_AUTHOR_NAME]="chaotic-aur" [REDIS_SSH_HOST]="localhost" [REDIS_SSH_PORT]="22" [REDIS_SSH_USER]="redis" [REDIS_PORT]="6379" [REPO_NAME]="chaotic-aur" [CI_HUMAN_REVIEW]="false" [TEMPLATE_REPO]="https://github.com/chaotic-cx/chaotic-repository-template" [TEMPLATE_ENABLE_UPDATES]="true" [CI_MANAGE_AUR]="false" [CI_CLONE_DELAY]="0" [CI_AUR_PROXY]="" [CI_LIB_DB]="" [CI_CODE_SKIP]=123)
 
 EXCLUDE_FILES=(.CI .git .gitignore)
@@ -69,7 +68,6 @@ function UTIL_WRITE_KNOWN_VARIABLES_TO_FILE() {
 function UTIL_READ_MANAGED_PACAKGE() {
     set -euo pipefail
     local target_file="./${1}/.CI/config"
-    local target_state_file="./.state/${1}"
     local ret=1
     local -n READ_MANAGED_ASSOC_ARRAY=${2:-VARIABLES}
     if [ -f "$target_file" ]; then
@@ -84,11 +82,6 @@ function UTIL_READ_MANAGED_PACAKGE() {
         READ_MANAGED_ASSOC_ARRAY[CI_NO_CONFIG]=true
     fi
 
-    # This file might or might not exist depending on the current state of the application
-    if [ -f "$target_state_file" ]; then
-        UTIL_READ_KNOWN_VARIABLES_FROM_FILE "$target_state_file" READ_MANAGED_ASSOC_ARRAY KNOWN_STATE_VARIABLE_LIST
-    fi
-
     # shellcheck disable=2153
     READ_MANAGED_ASSOC_ARRAY[PKGBASE]="$1"
     return $ret
@@ -97,14 +90,9 @@ function UTIL_READ_MANAGED_PACAKGE() {
 function UTIL_WRITE_MANAGED_PACKAGE() {
     set -euo pipefail
     local target_file="./${1}/.CI/config"
-    local target_state_file="./.newstate/${1}"
     local -n WRITE_MANAGED_ASSOC_ARRAY=${2:-VARIABLES}
     if [[ ! -v WRITE_MANAGED_ASSOC_ARRAY[CI_NO_CONFIG] ]]; then
         UTIL_WRITE_KNOWN_VARIABLES_TO_FILE "$target_file" WRITE_MANAGED_ASSOC_ARRAY KNOWN_VARIABLE_LIST
-    fi
-    # Edge case: We do want to keep re-checking these to keep the pull review up to date
-    if [[ ! -v WRITE_MANAGED_ASSOC_ARRAY[CI_REQUIRES_REVIEW] ]] || [ "${WRITE_MANAGED_ASSOC_ARRAY[CI_REQUIRES_REVIEW]}" != "true" ]; then
-        UTIL_WRITE_KNOWN_VARIABLES_TO_FILE "$target_state_file" WRITE_MANAGED_ASSOC_ARRAY KNOWN_STATE_VARIABLE_LIST
     fi
 }
 
@@ -330,7 +318,7 @@ function UTIL_PARSE_DATABASE() {
         if [[ -v already_parsed["${normalized_pkgbase}"] ]]; then
             continue
         else
-            echo "$pkgbase:$version" >>"${tmp_dir}/versions.new"
+            echo "$pkgbase:$version" >>"${tmp_dir}/version-state"
             already_parsed["$normalized_pkgbase"]="true"
         fi
     done < <(find "${tmp_dir}/${repo}" -maxdepth 2 -name 'desc' -exec awk -f .ci/awk/parse-database.awk {} +)
@@ -352,19 +340,4 @@ function UTIL_PRINT_ERROR() {
 function UTIL_PRINT_INFO() {
     set -euo pipefail
     printf '\e[1;34mInfo:\e[0m %s\n' "$1"
-}
-
-# $1: pkgbase
-function UTIL_CHECK_STATE_DIFF() {
-    set -euo pipefail
-
-    if test -f "./.state/${1}" && test -f "./.newstate/${1}"; then
-        if diff -q "./.state/${1}" "./.newstate/${1}" >/dev/null; then
-            return 0
-        else
-            return 1
-        fi
-    else
-        return 0
-    fi
 }

--- a/.ci/util.shlib
+++ b/.ci/util.shlib
@@ -3,7 +3,7 @@
 
 KNOWN_VARIABLE_LIST=(CI_PKGBUILD_SOURCE CI_PACKAGE_BUMP CI_ON_TRIGGER CI_MANAGE_AUR BUILDER_CACHE_SOURCES BUILDER_EXTRA_TIMEOUT CI_REBUILD_TRIGGERS)
 KNOWN_STATE_VARIABLE_LIST=(CI_GIT_COMMIT CI_PKGBUILD_TIMESTAMP)
-declare -A KNOWN_CONFIG_LIST=([BUILD_REPO]="chaotic-aur" [GIT_AUTHOR_EMAIL]="ci@example.com" [GIT_AUTHOR_NAME]="chaotic-aur" [REDIS_SSH_HOST]="localhost" [REDIS_SSH_PORT]="22" [REDIS_SSH_USER]="redis" [REDIS_PORT]="6379" [REPO_NAME]="chaotic-aur" [CI_HUMAN_REVIEW]="false" [TEMPLATE_REPO]="https://github.com/chaotic-cx/chaotic-repository-template" [TEMPLATE_ENABLE_UPDATES]="true" [CI_MANAGE_AUR]="false" [CI_OVERWRITE_COMMITS]="true" [CI_CLONE_DELAY]="0" [CI_AUR_PROXY]="" [CI_LIB_DB]="" [CI_CODE_SKIP]=123)
+declare -A KNOWN_CONFIG_LIST=([BUILD_REPO]="chaotic-aur" [GIT_AUTHOR_EMAIL]="ci@example.com" [GIT_AUTHOR_NAME]="chaotic-aur" [REDIS_SSH_HOST]="localhost" [REDIS_SSH_PORT]="22" [REDIS_SSH_USER]="redis" [REDIS_PORT]="6379" [REPO_NAME]="chaotic-aur" [CI_HUMAN_REVIEW]="false" [TEMPLATE_REPO]="https://github.com/chaotic-cx/chaotic-repository-template" [TEMPLATE_ENABLE_UPDATES]="true" [CI_MANAGE_AUR]="false" [CI_CLONE_DELAY]="0" [CI_AUR_PROXY]="" [CI_LIB_DB]="" [CI_CODE_SKIP]=123)
 
 EXCLUDE_FILES=(.CI .git .gitignore)
 


### PR DESCRIPTION
Revert some of the compromise features that were intended to make the commit history more manageable. Unfortunately, these compromise features do add a lot of tech debt or have downsides that are not really acceptable to me (the inability to git pull because of the force pushes, for example).
This reverts those features as well as fixing some things on the library based auto-bump side of things as well.

We will have to find different approaches to address the commit history readability. A website-based tool or separate branch that has the commit history cleaned up might be doable.