### PR TITLE
fix(on-schedule): advance CI_PACKAGE_BUMP past stale version-state

### DIFF
--- a/.ci/on-schedule.sh
+++ b/.ci/on-schedule.sh
@@ -197,6 +197,13 @@ function update-lib-bump() {
       UTIL_PRINT_WARNING "$package: Could not find package version in the version-state file."
       return 0
     fi
+
+    if [[ -v pkg_config[CI_PACKAGE_BUMP] ]] && [[ "${pkg_config[CI_PACKAGE_BUMP]}" =~ ^(.+)/([0-9]+)$ ]]; then
+      if [[ "${BASH_REMATCH[1]}" == "$_DB_BASE" ]] && [ "${BASH_REMATCH[2]}" -ge "$_DB_BUMP" ]; then
+        _DB_BUMP=$((${BASH_REMATCH[2]} + 1))
+      fi
+    fi
+
     pkg_config[CI_PACKAGE_BUMP]="$_DB_BASE/$_DB_BUMP"
     pkg_config[CI_ANY_UPDATE]=true
   fi


### PR DESCRIPTION
**Summary**

This fixes a bug in `on-schedule`'s library-triggered rebuild logic where `CI_PACKAGE_BUMP` could get stuck and stop producing real rebuilds.

The issue happens when:
- a rebuild trigger is detected from `version-state`
- `on-schedule` computes the next bump from the published package version in `.state/.version-state`
- but `.CI/config` already contains a newer `CI_PACKAGE_BUMP` that never made it into the published repo

In that situation, the script can log that it is "bumping pkgrel", but end up recomputing the exact same `CI_PACKAGE_BUMP` value already present in `.CI/config`. That produces no diff, so no commit is created, no package is scheduled, and the rebuild silently does not happen.

**User-visible symptom**

The concrete case that exposed this was:
- `bluespec-contrib-git` has `CI_REBUILD_TRIGGERS=bluespec-git`
- `bluespec-git` was rebuilt and its published version in the repo advanced
- `on-schedule` detected the trigger and printed the expected log message for `bluespec-contrib-git`
- but `bluespec-contrib-git` did not actually rebuild

Inspection showed that:
- `bluespec-contrib-git/.CI/config` already had `CI_PACKAGE_BUMP=r54.1ec02af-1/2`
- the published repo still had `bluespec-contrib-git r54.1ec02af-1.1`
- when `on-schedule` ran again, it derived the next bump from the published state and recomputed `/2`
- since `/2` was already in `.CI/config`, there was no change to commit

So the trigger path was firing, but the computed result was a no-op.

**Root cause**

`update-lib-bump()` currently trusts `.state/.version-state` as the only source of truth for the latest effective bump.

That assumption breaks when git and the published repo diverge, for example if:
- a previous auto-bump was committed
- but the corresponding build never completed, never published, or otherwise did not reach the repo DB

Once that happens, later trigger runs can continue to derive the same stale "next" bump from `version-state`, even though `.CI/config` is already ahead.

**Fix**

When `on-schedule` computes a new bump from `.state/.version-state`, also look at the existing `CI_PACKAGE_BUMP` already present in `.CI/config`.

If:
- the base version matches (`pkgver-pkgrel`)
- and the configured bump is already greater than or equal to the DB-derived next bump

then advance from the configured bump instead.

In other words:
- if published state is ahead, follow published state
- if config is ahead, continue from config

This makes bump progression monotonic and prevents rebuild-trigger no-ops when publication lags behind committed bump state.

**Why this is safe**

The change is intentionally minimal and local to `update-lib-bump()`.

It does not alter:
- how library changes are detected
- how `CI_REBUILD_TRIGGERS` are matched
- how base versions are parsed
- behavior when the base version changes

If `pkgver-pkgrel` changes, the logic still resets to the DB-derived bump for the new base, which is the correct behavior.

The new behavior only affects the case where:
- `.CI/config` already contains a bump for the same base
- and that bump is ahead of what `version-state` would otherwise derive

**Why this is needed**

Without this, the system can enter a stuck state where:
1. a trigger is detected
2. the log says a bump is happening
3. the recomputed bump equals the existing config
4. no file changes
5. no commit
6. no schedule
7. downstream package never rebuilds

That makes rebuild-trigger failures very hard to diagnose because the logs look superficially correct.
